### PR TITLE
Allow default migrations to be ignored

### DIFF
--- a/src/Wallet.php
+++ b/src/Wallet.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Bavix\Wallet;
+
+class Wallet
+{
+    /**
+     * Indicates if Wallet migrations will be run.
+     *
+     * @var bool
+     */
+    public static $runsMigrations = true;
+
+    /**
+     * Configure Wallet to not register its migrations.
+     *
+     * @return static
+     */
+    public static function ignoreMigrations()
+    {
+        static::$runsMigrations = false;
+
+        return new static;
+    }
+}

--- a/src/WalletServiceProvider.php
+++ b/src/WalletServiceProvider.php
@@ -21,6 +21,7 @@ use Bavix\Wallet\Simple\Math;
 use Bavix\Wallet\Services\WalletService;
 use Bavix\Wallet\Simple\Rate;
 use Bavix\Wallet\Simple\Store;
+use Bavix\Wallet\Wallet as WalletConfiguration;
 use Illuminate\Support\ServiceProvider;
 use function config;
 use function dirname;
@@ -48,10 +49,12 @@ class WalletServiceProvider extends ServiceProvider
 
         $this->commands([RefreshBalance::class]);
 
-        $this->loadMigrationsFrom([
-            __DIR__ . '/../database/migrations_v1',
-            __DIR__ . '/../database/migrations_v2',
-        ]);
+        if ($this->shouldMigrate()) {
+            $this->loadMigrationsFrom([
+                __DIR__ . '/../database/migrations_v1',
+                __DIR__ . '/../database/migrations_v2',
+            ]);
+        }
 
         if (function_exists('config_path')) {
             $this->publishes([
@@ -107,4 +110,13 @@ class WalletServiceProvider extends ServiceProvider
         $this->app->bind(Operation::class, config('wallet.objects.operation', Operation::class));
     }
 
+    /**
+     * Determine if we should register the migrations.
+     *
+     * @return bool
+     */
+    protected function shouldMigrate()
+    {
+        return WalletConfiguration::$runsMigrations;
+    }
 }


### PR DESCRIPTION
Borrowing from Laravel's official packages, this allows default migrations to be ignored.

Calling the Wallet::ignoreMigrations method in the register method of your AppServiceProvider will prevent the default migrations from being run.

As noted [in the documentation](https://bavix.github.io/laravel-wallet/#/installation?id=run-migrations), the default migrations can be published with the `php artisan vendor:publish --tag=laravel-wallet-migrations` command.

Example:

```
use Bavix\Wallet\Wallet;

class AppServiceProvider extends ServiceProvider
{
    /**
     * Register any application services.
     *
     * @return void
     */
    public function register()
    {
        Wallet::ignoreMigrations();
    }
```