### PR TITLE
Fixed migration issue with db table prefix

### DIFF
--- a/database/migrations_v2/2019_05_13_111553_update_status_transfers_table.php
+++ b/database/migrations_v2/2019_05_13_111553_update_status_transfers_table.php
@@ -32,7 +32,7 @@ class UpdateStatusTransfersTable extends Migration
         ];
 
         if (DB::connection() instanceof MySqlConnection) {
-            $table = $this->table();
+            $table = DB::getTablePrefix() . $this->table();
             $enumString = implode('\', \'', $enums);
             $default = Transfer::STATUS_TRANSFER;
             DB::statement("ALTER TABLE $table CHANGE COLUMN status status ENUM('$enumString') NOT NULL DEFAULT '$default'");
@@ -41,8 +41,8 @@ class UpdateStatusTransfersTable extends Migration
         }
 
         if (DB::connection() instanceof PostgresConnection) {
-            $this->alterEnum($this->table(), 'status', $enums);
-            $this->alterEnum($this->table(), 'status_last', $enums);
+            $this->alterEnum(DB::getTablePrefix() . $this->table(), 'status', $enums);
+            $this->alterEnum(DB::getTablePrefix() . $this->table(), 'status_last', $enums);
             return;
         }
 
@@ -77,7 +77,7 @@ class UpdateStatusTransfersTable extends Migration
         ];
 
         if (DB::connection() instanceof MySqlConnection) {
-            $table = $this->table();
+            $table = DB::getTablePrefix() . $this->table();
             $enumString = implode('\', \'', $enums);
             $default = Transfer::STATUS_PAID;
             DB::statement("ALTER TABLE $table CHANGE COLUMN status status ENUM('$enumString') NOT NULL DEFAULT '$default'");
@@ -86,8 +86,8 @@ class UpdateStatusTransfersTable extends Migration
         }
 
         if (DB::connection() instanceof PostgresConnection) {
-            $this->alterEnum($this->table(), 'status', $enums);
-            $this->alterEnum($this->table(), 'status_last', $enums);
+            $this->alterEnum(DB::getTablePrefix() . $this->table(), 'status', $enums);
+            $this->alterEnum(DB::getTablePrefix() . $this->table(), 'status_last', $enums);
             return;
         }
 

--- a/database/migrations_v2/2019_06_25_103755_add_exchange_status_transfers_table.php
+++ b/database/migrations_v2/2019_06_25_103755_add_exchange_status_transfers_table.php
@@ -31,7 +31,7 @@ class AddExchangeStatusTransfersTable extends Migration
         ];
 
         if (DB::connection() instanceof MySqlConnection) {
-            $table = $this->table();
+            $table = DB::getTablePrefix() . $this->table();
             $enumString = implode('\', \'', $enums);
             $default = Transfer::STATUS_TRANSFER;
             DB::statement("ALTER TABLE $table CHANGE COLUMN status status ENUM('$enumString') NOT NULL DEFAULT '$default'");
@@ -40,8 +40,8 @@ class AddExchangeStatusTransfersTable extends Migration
         }
 
         if (DB::connection() instanceof PostgresConnection) {
-            $this->alterEnum($this->table(), 'status', $enums);
-            $this->alterEnum($this->table(), 'status_last', $enums);
+            $this->alterEnum(DB::getTablePrefix() . $this->table(), 'status', $enums);
+            $this->alterEnum(DB::getTablePrefix() . $this->table(), 'status_last', $enums);
             return;
         }
     }
@@ -59,7 +59,7 @@ class AddExchangeStatusTransfersTable extends Migration
         ];
 
         if (DB::connection() instanceof MySqlConnection) {
-            $table = $this->table();
+            $table = DB::getTablePrefix() . $this->table();
             $enumString = implode('\', \'', $enums);
             $default = Transfer::STATUS_TRANSFER;
             DB::statement("ALTER TABLE $table CHANGE COLUMN status status ENUM('$enumString') NOT NULL DEFAULT '$default'");
@@ -68,8 +68,8 @@ class AddExchangeStatusTransfersTable extends Migration
         }
 
         if (DB::connection() instanceof PostgresConnection) {
-            $this->alterEnum($this->table(), 'status', $enums);
-            $this->alterEnum($this->table(), 'status_last', $enums);
+            $this->alterEnum(DB::getTablePrefix() . $this->table(), 'status', $enums);
+            $this->alterEnum(DB::getTablePrefix() . $this->table(), 'status_last', $enums);
             return;
         }
     }


### PR DESCRIPTION
Faced issue while executing migrations. Identified that in some migrations, DB::statement is being used and when DB Table Prefix is configured in the config/database.php file, it is not building the correct table names in those statements.

For the fix, the `DB::getTablePrefix()` is appended to all the places where the table name is being used as a direct statement.

Kindly accept PR or share feedback for corrections if required.