### PR TITLE
Add a relation for fetching transactions from the wallet (walletTransactions)

### DIFF
--- a/src/Interfaces/Wallet.php
+++ b/src/Interfaces/Wallet.php
@@ -12,6 +12,7 @@ use Bavix\Wallet\Internal\Exceptions\LockProviderNotFoundException;
 use Bavix\Wallet\Internal\Exceptions\TransactionFailedException;
 use Bavix\Wallet\Models\Transaction;
 use Bavix\Wallet\Models\Transfer;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\RecordsNotFoundException;
 
@@ -90,6 +91,8 @@ interface Wallet
     public function getBalanceAttribute();
 
     public function getBalanceIntAttribute(): int;
+
+    public function walletTransactions(): HasMany;
 
     public function transactions(): MorphMany;
 

--- a/src/Models/Wallet.php
+++ b/src/Models/Wallet.php
@@ -134,8 +134,7 @@ class Wallet extends Model implements Customer, WalletFloat, Confirmable, Exchan
      */
     public function getAvailableBalanceAttribute()
     {
-        return $this->transactions()
-            ->where('wallet_id', $this->getKey())
+        return $this->walletTransactions()
             ->where('confirmed', true)
             ->sum('amount')
         ;

--- a/src/Traits/HasWallet.php
+++ b/src/Traits/HasWallet.php
@@ -22,6 +22,7 @@ use Bavix\Wallet\Services\CommonServiceLegacy;
 use Bavix\Wallet\Services\ConsistencyServiceInterface;
 use Bavix\Wallet\Services\RegulatorServiceInterface;
 use function config;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\RecordsNotFoundException;
 use Illuminate\Support\Collection;
@@ -91,6 +92,17 @@ trait HasWallet
     public function getBalanceIntAttribute(): int
     {
         return (int) $this->getBalanceAttribute();
+    }
+
+    /**
+     * We receive transactions of the selected wallet.
+     */
+    public function walletTransactions(): HasMany
+    {
+        return app(CastServiceInterface::class)
+            ->getWallet($this)
+            ->hasMany(config('wallet.transaction.model', Transaction::class), 'wallet_id')
+        ;
     }
 
     /**

--- a/tests/Units/Domain/MultiWalletTest.php
+++ b/tests/Units/Domain/MultiWalletTest.php
@@ -234,6 +234,26 @@ class MultiWalletTest extends TestCase
         $wallet->withdraw(1);
     }
 
+    public function testWalletTransactions(): void
+    {
+        /** @var UserMulti $user */
+        $user = UserMultiFactory::new()->create();
+        $usd = $user->createWallet(['name' => 'USD']);
+        $eur = $user->createWallet(['name' => 'EUR']);
+
+        $usd->deposit(100);
+        $eur->deposit(200);
+        $eur->withdraw(50);
+
+        self::assertCount(3, $user->transactions()->get());
+        self::assertCount(3, $usd->transactions()->get());
+        self::assertCount(3, $eur->transactions()->get());
+
+        self::assertCount(0, $user->walletTransactions()->get());
+        self::assertCount(1, $usd->walletTransactions()->get());
+        self::assertCount(2, $eur->walletTransactions()->get());
+    }
+
     public function testInvalidWithdraw(): void
     {
         $this->expectException(BalanceIsEmpty::class);

--- a/tests/Units/Domain/MultiWalletTest.php
+++ b/tests/Units/Domain/MultiWalletTest.php
@@ -245,13 +245,15 @@ class MultiWalletTest extends TestCase
         $eur->deposit(200);
         $eur->withdraw(50);
 
-        self::assertCount(3, $user->transactions()->get());
-        self::assertCount(3, $usd->transactions()->get());
-        self::assertCount(3, $eur->transactions()->get());
+        self::assertSame(3, $user->transactions()->count());
+        self::assertSame(3, $user->wallet->transactions()->count());
+        self::assertSame(3, $usd->transactions()->count());
+        self::assertSame(3, $eur->transactions()->count());
 
-        self::assertCount(0, $user->walletTransactions()->get());
-        self::assertCount(1, $usd->walletTransactions()->get());
-        self::assertCount(2, $eur->walletTransactions()->get());
+        self::assertSame(0, $user->walletTransactions()->count());
+        self::assertSame(0, $user->wallet->walletTransactions()->count());
+        self::assertSame(1, $usd->walletTransactions()->count());
+        self::assertSame(2, $eur->walletTransactions()->count());
     }
 
     public function testInvalidWithdraw(): void


### PR DESCRIPTION
#416 

```php
// default wallet
$user->deposit(100);
$user->wallet->deposit(200);
$user->wallet->withdraw(1);

// usd
$usd = $user->createWallet(['name' => 'USD']);
$usd->deposit(100);

// eur
$eur = $user->createWallet(['name' => 'EUR']);
$eur->deposit(100);

$user->transactions()->count(); // 5
$user->wallet->transactions()->count(); // 5
$usd->transactions()->count(); // 5
$eur->transactions()->count(); // 5
// the transactions method returns data relative to the owner of the wallet, for all transactions

$user->walletTransactions()->count(); // 3. we get the default wallet
$user->wallet->walletTransactions()->count(); // 3
$usd->walletTransactions()->count(); // 1
$eur->walletTransactions()->count(); // 1
```