### PR TITLE
Extend Wallet holder_id property to support string type

### DIFF
--- a/src/Internal/Dto/TransactionDto.php
+++ b/src/Internal/Dto/TransactionDto.php
@@ -12,7 +12,7 @@ final class TransactionDto implements TransactionDtoInterface
     private string $uuid;
 
     private string $payableType;
-    private int $payableId;
+    private int|string $payableId;
 
     private int $walletId;
 
@@ -30,7 +30,7 @@ final class TransactionDto implements TransactionDtoInterface
     public function __construct(
         string $uuid,
         string $payableType,
-        int $payableId,
+        int|string $payableId,
         int $walletId,
         string $type,
         string $amount,
@@ -59,7 +59,7 @@ final class TransactionDto implements TransactionDtoInterface
         return $this->payableType;
     }
 
-    public function getPayableId(): int
+    public function getPayableId(): int|string
     {
         return $this->payableId;
     }

--- a/src/Internal/Dto/TransactionDtoInterface.php
+++ b/src/Internal/Dto/TransactionDtoInterface.php
@@ -12,7 +12,7 @@ interface TransactionDtoInterface
 
     public function getPayableType(): string;
 
-    public function getPayableId(): int;
+    public function getPayableId(): int|string;
 
     public function getWalletId(): int;
 

--- a/src/Internal/Dto/TransferDto.php
+++ b/src/Internal/Dto/TransferDto.php
@@ -17,10 +17,10 @@ final class TransferDto implements TransferDtoInterface
     private string $status;
 
     private string $fromType;
-    private int $fromId;
+    private int|string $fromId;
 
     private string $toType;
-    private int $toId;
+    private int|string $toId;
 
     private int $discount;
     private string $fee;
@@ -34,9 +34,9 @@ final class TransferDto implements TransferDtoInterface
         int $withdrawId,
         string $status,
         string $fromType,
-        int $fromId,
+        int|string $fromId,
         string $toType,
-        int $toId,
+        int|string $toId,
         int $discount,
         string $fee
     ) {
@@ -79,7 +79,7 @@ final class TransferDto implements TransferDtoInterface
         return $this->fromType;
     }
 
-    public function getFromId(): int
+    public function getFromId(): int|string
     {
         return $this->fromId;
     }
@@ -89,7 +89,7 @@ final class TransferDto implements TransferDtoInterface
         return $this->toType;
     }
 
-    public function getToId(): int
+    public function getToId(): int|string
     {
         return $this->toId;
     }

--- a/src/Internal/Dto/TransferDtoInterface.php
+++ b/src/Internal/Dto/TransferDtoInterface.php
@@ -18,11 +18,11 @@ interface TransferDtoInterface
 
     public function getFromType(): string;
 
-    public function getFromId(): int;
+    public function getFromId(): int|string;
 
     public function getToType(): string;
 
-    public function getToId(): int;
+    public function getToId(): int|string;
 
     public function getDiscount(): int;
 


### PR DESCRIPTION
This PR extends wallet holder_id property to support string type.

In my use case, user id and item id are uuid strings.