### PR TITLE
cacheRepository uses $cache['driver'] option

### DIFF
--- a/src/WalletServiceProvider.php
+++ b/src/WalletServiceProvider.php
@@ -223,7 +223,7 @@ final class WalletServiceProvider extends ServiceProvider
                     StorageServiceInterface::class,
                     [
                         'cacheRepository' => $this->app->make(CacheManager::class)
-                            ->driver('array'),
+                            ->driver($cache['driver'] ?? 'array'),
                     ],
                 ),
             ]


### PR DESCRIPTION
Feel free to ignore this, just double checking, maybe this is not even an issue.

On current version 7.3.2 I am seeing following behaviour: 

Breakpoint on `StorageService.php` line 23. First time hitting the breakpoint the result is:

![image](https://user-images.githubusercontent.com/11991564/153718577-c8b32865-d1cb-4d06-9e61-a25dc64a2df6.png)

Second time (?) (see note below) hitting the breakpoint (still in the same request) yields:
![image](https://user-images.githubusercontent.com/11991564/153718703-ec80f224-429d-4297-8828-985e228a8ea1.png)

The change in this PR fixes it so that on both (?) breakpoint hits it now has the `RedisStore` instance


Note:
However I think this also highlights another issue (or maybe im misunderstanding whats going on but I feel like 
the following code should yield a singleton so therefore I should not be hitting the `__construct` of `StorageService` twice?

```php
 'storageService' => $this->app->make(
                    StorageServiceInterface::class,
                    [
                        'cacheRepository' => $this->app->make(CacheManager::class)
                            ->driver($cache['driver'] ?? 'array'),
                    ],
                ),
```

Or maybe there is 2 seperate instances of `storageService` required for something I am completely missing and its actually valid?

The reason why I am trying to double check this is because I have a laravel queue running in another docker container to my php-fpm contaner so I need to make sure both instances access the same `redis` instances and I dont end up with diverging balances