### PR TITLE
[9.x] Split Product interface

### DIFF
--- a/src/Interfaces/Customer.php
+++ b/src/Interfaces/Customer.php
@@ -27,33 +27,33 @@ interface Customer extends Wallet
      * @throws TransactionFailedException
      * @throws ExceptionInterface
      */
-    public function payFree(Product $product): Transfer;
+    public function payFree(ProductInterface $product): Transfer;
 
-    public function safePay(Product $product, bool $force = false): ?Transfer;
-
-    /**
-     * @throws ProductEnded
-     * @throws BalanceIsEmpty
-     * @throws InsufficientFunds
-     * @throws LockProviderNotFoundException
-     * @throws RecordNotFoundException
-     * @throws RecordsNotFoundException
-     * @throws TransactionFailedException
-     * @throws ExceptionInterface
-     */
-    public function pay(Product $product, bool $force = false): Transfer;
+    public function safePay(ProductInterface $product, bool $force = false): ?Transfer;
 
     /**
      * @throws ProductEnded
+     * @throws BalanceIsEmpty
+     * @throws InsufficientFunds
      * @throws LockProviderNotFoundException
      * @throws RecordNotFoundException
      * @throws RecordsNotFoundException
      * @throws TransactionFailedException
      * @throws ExceptionInterface
      */
-    public function forcePay(Product $product): Transfer;
+    public function pay(ProductInterface $product, bool $force = false): Transfer;
 
-    public function safeRefund(Product $product, bool $force = false, bool $gifts = false): bool;
+    /**
+     * @throws ProductEnded
+     * @throws LockProviderNotFoundException
+     * @throws RecordNotFoundException
+     * @throws RecordsNotFoundException
+     * @throws TransactionFailedException
+     * @throws ExceptionInterface
+     */
+    public function forcePay(ProductInterface $product): Transfer;
+
+    public function safeRefund(ProductInterface $product, bool $force = false, bool $gifts = false): bool;
 
     /**
      * @throws BalanceIsEmpty
@@ -65,7 +65,7 @@ interface Customer extends Wallet
      * @throws ModelNotFoundException
      * @throws ExceptionInterface
      */
-    public function refund(Product $product, bool $force = false, bool $gifts = false): bool;
+    public function refund(ProductInterface $product, bool $force = false, bool $gifts = false): bool;
 
     /**
      * @throws LockProviderNotFoundException
@@ -75,9 +75,9 @@ interface Customer extends Wallet
      * @throws ModelNotFoundException
      * @throws ExceptionInterface
      */
-    public function forceRefund(Product $product, bool $gifts = false): bool;
+    public function forceRefund(ProductInterface $product, bool $gifts = false): bool;
 
-    public function safeRefundGift(Product $product, bool $force = false): bool;
+    public function safeRefundGift(ProductInterface $product, bool $force = false): bool;
 
     /**
      * @throws BalanceIsEmpty
@@ -89,7 +89,7 @@ interface Customer extends Wallet
      * @throws ModelNotFoundException
      * @throws ExceptionInterface
      */
-    public function refundGift(Product $product, bool $force = false): bool;
+    public function refundGift(ProductInterface $product, bool $force = false): bool;
 
     /**
      * @throws LockProviderNotFoundException
@@ -99,7 +99,7 @@ interface Customer extends Wallet
      * @throws ModelNotFoundException
      * @throws ExceptionInterface
      */
-    public function forceRefundGift(Product $product): bool;
+    public function forceRefundGift(ProductInterface $product): bool;
 
     /**
      * @throws ProductEnded
@@ -199,5 +199,5 @@ interface Customer extends Wallet
      *
      * @deprecated The method is slow and will be removed in the future
      */
-    public function paid(Product $product, bool $gifts = false): ?Transfer;
+    public function paid(ProductInterface $product, bool $gifts = false): ?Transfer;
 }

--- a/src/Interfaces/Product.php
+++ b/src/Interfaces/Product.php
@@ -4,22 +4,14 @@ declare(strict_types=1);
 
 namespace Bavix\Wallet\Interfaces;
 
-interface Product extends Wallet
+/**
+ * If the product is always in stock, then the ProductInterface must be used. If the product may not be available, then
+ * there is a need to use the ProductLimitedInterface.
+ *
+ * @deprecated The class is deprecated. Will be removed in the future.
+ * @see ProductInterface
+ * @see ProductLimitedInterface
+ */
+interface Product extends ProductLimitedInterface
 {
-    /**
-     * The method is only needed for simple projects. For more complex projects, deprecate this method and redefine the
-     * "BasketServiceInterface" interface. Typically, in projects, this method always returns false, and the presence
-     * interface goes to the microservice and receives data on products.
-     */
-    public function canBuy(Customer $customer, int $quantity = 1, bool $force = false): bool;
-
-    /**
-     * @return float|int|string
-     */
-    public function getAmountProduct(Customer $customer);
-
-    /**
-     * @return array
-     */
-    public function getMetaProduct(): ?array;
 }

--- a/src/Interfaces/ProductInterface.php
+++ b/src/Interfaces/ProductInterface.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Bavix\Wallet\Interfaces;
 
-/**
- * @internal
- */
 interface ProductInterface extends Wallet
 {
     /**

--- a/src/Interfaces/ProductInterface.php
+++ b/src/Interfaces/ProductInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bavix\Wallet\Interfaces;
+
+/**
+ * @internal
+ */
+interface ProductInterface extends Wallet
+{
+    /**
+     * @return float|int|string
+     */
+    public function getAmountProduct(Customer $customer);
+
+    public function getMetaProduct(): ?array;
+}

--- a/src/Interfaces/ProductLimitedInterface.php
+++ b/src/Interfaces/ProductLimitedInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bavix\Wallet\Interfaces;
+
+interface ProductLimitedInterface extends ProductInterface
+{
+    /**
+     * The method is only needed for simple projects. For more complex projects, deprecate this method and redefine the
+     * "BasketServiceInterface" interface. Typically, in projects, this method always returns false, and the presence
+     * interface goes to the microservice and receives data on products.
+     */
+    public function canBuy(Customer $customer, int $quantity = 1, bool $force = false): bool;
+}

--- a/src/Internal/Dto/BasketDto.php
+++ b/src/Internal/Dto/BasketDto.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Bavix\Wallet\Internal\Dto;
 
-use Bavix\Wallet\Interfaces\Product;
+use Bavix\Wallet\Interfaces\ProductInterface;
 use Generator;
 
 final class BasketDto implements BasketDtoInterface
@@ -34,7 +34,7 @@ final class BasketDto implements BasketDtoInterface
     }
 
     /**
-     * @return Generator<array-key, Product, mixed, void>
+     * @return Generator<array-key, ProductInterface, mixed, void>
      */
     public function cursor(): Generator
     {

--- a/src/Internal/Dto/BasketDtoInterface.php
+++ b/src/Internal/Dto/BasketDtoInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Bavix\Wallet\Internal\Dto;
 
-use Bavix\Wallet\Interfaces\Product;
+use Bavix\Wallet\Interfaces\ProductInterface;
 use Countable;
 use Generator;
 
@@ -20,7 +20,7 @@ interface BasketDtoInterface extends Countable
     public function items(): array;
 
     /**
-     * @return Generator<array-key, Product, mixed, void>
+     * @return Generator<array-key, ProductInterface, mixed, void>
      */
     public function cursor(): Generator;
 }

--- a/src/Internal/Dto/ItemDto.php
+++ b/src/Internal/Dto/ItemDto.php
@@ -4,26 +4,26 @@ declare(strict_types=1);
 
 namespace Bavix\Wallet\Internal\Dto;
 
-use Bavix\Wallet\Interfaces\Product;
+use Bavix\Wallet\Interfaces\ProductInterface;
 
 /** @psalm-immutable */
 final class ItemDto implements ItemDtoInterface
 {
     public function __construct(
-        private Product $product,
+        private ProductInterface $product,
         private int $quantity
     ) {
     }
 
     /**
-     * @return Product[]
+     * @return ProductInterface[]
      */
     public function items(): array
     {
         return array_fill(0, $this->quantity, $this->product);
     }
 
-    public function product(): Product
+    public function product(): ProductInterface
     {
         return $this->product;
     }

--- a/src/Internal/Dto/ItemDtoInterface.php
+++ b/src/Internal/Dto/ItemDtoInterface.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Bavix\Wallet\Internal\Dto;
 
-use Bavix\Wallet\Interfaces\Product;
+use Bavix\Wallet\Interfaces\ProductInterface;
 use Countable;
 
 interface ItemDtoInterface extends Countable
 {
     /**
-     * @return Product[]
+     * @return ProductInterface[]
      */
     public function items(): array;
 
     public function count(): int;
 
-    public function product(): Product;
+    public function product(): ProductInterface;
 }

--- a/src/Objects/Cart.php
+++ b/src/Objects/Cart.php
@@ -6,7 +6,7 @@ namespace Bavix\Wallet\Objects;
 
 use Bavix\Wallet\Interfaces\CartInterface;
 use Bavix\Wallet\Interfaces\Customer;
-use Bavix\Wallet\Interfaces\Product;
+use Bavix\Wallet\Interfaces\ProductInterface;
 use Bavix\Wallet\Internal\Dto\BasketDto;
 use Bavix\Wallet\Internal\Dto\BasketDtoInterface;
 use Bavix\Wallet\Internal\Dto\ItemDto;
@@ -21,7 +21,7 @@ use Countable;
 final class Cart implements Countable, CartInterface
 {
     /**
-     * @var Product[]
+     * @var ProductInterface[]
      */
     private array $items = [];
 
@@ -64,7 +64,7 @@ final class Cart implements Countable, CartInterface
         return $this;
     }
 
-    public function withItem(Product $product, int $quantity = 1): self
+    public function withItem(ProductInterface $product, int $quantity = 1): self
     {
         $self = clone $this;
 
@@ -82,7 +82,7 @@ final class Cart implements Countable, CartInterface
      * @deprecated
      * @see withItem
      */
-    public function addItem(Product $product, int $quantity = 1): self
+    public function addItem(ProductInterface $product, int $quantity = 1): self
     {
         $productId = $this->productId($product);
 
@@ -118,7 +118,7 @@ final class Cart implements Countable, CartInterface
     }
 
     /**
-     * @return Product[]
+     * @return ProductInterface[]
      */
     public function getItems(): array
     {
@@ -134,7 +134,7 @@ final class Cart implements Countable, CartInterface
     }
 
     /**
-     * @return Product[]
+     * @return ProductInterface[]
      */
     public function getUniqueItems(): array
     {
@@ -157,7 +157,7 @@ final class Cart implements Countable, CartInterface
         return count($this->items);
     }
 
-    public function getQuantity(Product $product): int
+    public function getQuantity(ProductInterface $product): int
     {
         return $this->quantity[$this->productId($product)] ?? 0;
     }
@@ -168,7 +168,7 @@ final class Cart implements Countable, CartInterface
     public function getBasketDto(): BasketDtoInterface
     {
         $items = array_map(
-            fn (Product $product): ItemDtoInterface => new ItemDto($product, $this->getQuantity($product)),
+            fn (ProductInterface $product): ItemDtoInterface => new ItemDto($product, $this->getQuantity($product)),
             $this->getUniqueItems()
         );
 
@@ -179,7 +179,7 @@ final class Cart implements Countable, CartInterface
         return new BasketDto($items, $this->getMeta());
     }
 
-    private function productId(Product $product): string
+    private function productId(ProductInterface $product): string
     {
         return $product::class.':'.$this->castService->getModel($product)->getKey();
     }

--- a/src/Services/BasketService.php
+++ b/src/Services/BasketService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bavix\Wallet\Services;
 
+use Bavix\Wallet\Interfaces\ProductLimitedInterface;
 use Bavix\Wallet\Internal\Dto\AvailabilityDtoInterface;
 
 final class BasketService implements BasketServiceInterface
@@ -13,7 +14,12 @@ final class BasketService implements BasketServiceInterface
         $basketDto = $availabilityDto->getBasketDto();
         $customer = $availabilityDto->getCustomer();
         foreach ($basketDto->items() as $itemDto) {
-            if (!$itemDto->product()->canBuy($customer, $itemDto->count(), $availabilityDto->isForce())) {
+            $product = $itemDto->product();
+            if ($product instanceof ProductLimitedInterface && !$product->canBuy(
+                $customer,
+                $itemDto->count(),
+                $availabilityDto->isForce()
+            )) {
                 return false;
             }
         }

--- a/src/Services/MetaServiceLegacy.php
+++ b/src/Services/MetaServiceLegacy.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Bavix\Wallet\Services;
 
 use Bavix\Wallet\Interfaces\CartInterface;
-use Bavix\Wallet\Interfaces\Product;
+use Bavix\Wallet\Interfaces\ProductInterface;
 
 /** @deprecated */
 final class MetaServiceLegacy
 {
-    public function getMeta(CartInterface $cart, Product $product): ?array
+    public function getMeta(CartInterface $cart, ProductInterface $product): ?array
     {
         $metaCart = $cart->getBasketDto()
             ->meta()

--- a/src/Traits/CanPay.php
+++ b/src/Traits/CanPay.php
@@ -7,7 +7,7 @@ namespace Bavix\Wallet\Traits;
 use Bavix\Wallet\Exceptions\BalanceIsEmpty;
 use Bavix\Wallet\Exceptions\InsufficientFunds;
 use Bavix\Wallet\Exceptions\ProductEnded;
-use Bavix\Wallet\Interfaces\Product;
+use Bavix\Wallet\Interfaces\ProductInterface;
 use Bavix\Wallet\Internal\Exceptions\ExceptionInterface;
 use Bavix\Wallet\Internal\Exceptions\LockProviderNotFoundException;
 use Bavix\Wallet\Internal\Exceptions\ModelNotFoundException;
@@ -36,12 +36,12 @@ trait CanPay
      * @throws TransactionFailedException
      * @throws ExceptionInterface
      */
-    public function payFree(Product $product): Transfer
+    public function payFree(ProductInterface $product): Transfer
     {
         return current($this->payFreeCart(app(Cart::class)->withItem($product)));
     }
 
-    public function safePay(Product $product, bool $force = false): ?Transfer
+    public function safePay(ProductInterface $product, bool $force = false): ?Transfer
     {
         return current($this->safePayCart(app(Cart::class)->withItem($product), $force)) ?: null;
     }
@@ -56,7 +56,7 @@ trait CanPay
      * @throws TransactionFailedException
      * @throws ExceptionInterface
      */
-    public function pay(Product $product, bool $force = false): Transfer
+    public function pay(ProductInterface $product, bool $force = false): Transfer
     {
         return current($this->payCart(app(Cart::class)->withItem($product), $force));
     }
@@ -69,12 +69,12 @@ trait CanPay
      * @throws TransactionFailedException
      * @throws ExceptionInterface
      */
-    public function forcePay(Product $product): Transfer
+    public function forcePay(ProductInterface $product): Transfer
     {
         return current($this->forcePayCart(app(Cart::class)->withItem($product)));
     }
 
-    public function safeRefund(Product $product, bool $force = false, bool $gifts = false): bool
+    public function safeRefund(ProductInterface $product, bool $force = false, bool $gifts = false): bool
     {
         return $this->safeRefundCart(app(Cart::class)->withItem($product), $force, $gifts);
     }
@@ -89,7 +89,7 @@ trait CanPay
      * @throws ModelNotFoundException
      * @throws ExceptionInterface
      */
-    public function refund(Product $product, bool $force = false, bool $gifts = false): bool
+    public function refund(ProductInterface $product, bool $force = false, bool $gifts = false): bool
     {
         return $this->refundCart(app(Cart::class)->withItem($product), $force, $gifts);
     }
@@ -102,12 +102,12 @@ trait CanPay
      * @throws ModelNotFoundException
      * @throws ExceptionInterface
      */
-    public function forceRefund(Product $product, bool $gifts = false): bool
+    public function forceRefund(ProductInterface $product, bool $gifts = false): bool
     {
         return $this->forceRefundCart(app(Cart::class)->withItem($product), $gifts);
     }
 
-    public function safeRefundGift(Product $product, bool $force = false): bool
+    public function safeRefundGift(ProductInterface $product, bool $force = false): bool
     {
         return $this->safeRefundGiftCart(app(Cart::class)->withItem($product), $force);
     }
@@ -122,7 +122,7 @@ trait CanPay
      * @throws ModelNotFoundException
      * @throws ExceptionInterface
      */
-    public function refundGift(Product $product, bool $force = false): bool
+    public function refundGift(ProductInterface $product, bool $force = false): bool
     {
         return $this->refundGiftCart(app(Cart::class)->withItem($product), $force);
     }
@@ -135,7 +135,7 @@ trait CanPay
      * @throws ModelNotFoundException
      * @throws ExceptionInterface
      */
-    public function forceRefundGift(Product $product): bool
+    public function forceRefundGift(ProductInterface $product): bool
     {
         return $this->forceRefundGiftCart(app(Cart::class)->withItem($product));
     }

--- a/src/Traits/CartPay.php
+++ b/src/Traits/CartPay.php
@@ -9,7 +9,7 @@ use Bavix\Wallet\Exceptions\BalanceIsEmpty;
 use Bavix\Wallet\Exceptions\InsufficientFunds;
 use Bavix\Wallet\Exceptions\ProductEnded;
 use Bavix\Wallet\Interfaces\CartInterface;
-use Bavix\Wallet\Interfaces\Product;
+use Bavix\Wallet\Interfaces\ProductInterface;
 use Bavix\Wallet\Internal\Assembler\AvailabilityDtoAssemblerInterface;
 use Bavix\Wallet\Internal\Exceptions\ExceptionInterface;
 use Bavix\Wallet\Internal\Exceptions\LockProviderNotFoundException;
@@ -273,7 +273,7 @@ trait CartPay
      *
      * @deprecated The method is slow and will be removed in the future
      */
-    public function paid(Product $product, bool $gifts = false): ?Transfer
+    public function paid(ProductInterface $product, bool $gifts = false): ?Transfer
     {
         $cart = app(Cart::class)->withItem($product);
         $purchases = app(PurchaseServiceInterface::class)

--- a/src/Traits/HasGift.php
+++ b/src/Traits/HasGift.php
@@ -7,7 +7,7 @@ namespace Bavix\Wallet\Traits;
 use function app;
 use Bavix\Wallet\Exceptions\BalanceIsEmpty;
 use Bavix\Wallet\Exceptions\InsufficientFunds;
-use Bavix\Wallet\Interfaces\Product;
+use Bavix\Wallet\Interfaces\ProductInterface;
 use Bavix\Wallet\Interfaces\Wallet;
 use Bavix\Wallet\Internal\Assembler\TransferDtoAssemblerInterface;
 use Bavix\Wallet\Internal\Exceptions\ExceptionInterface;
@@ -35,7 +35,7 @@ trait HasGift
     /**
      * Give the goods safely.
      */
-    public function safeGift(Wallet $to, Product $product, bool $force = false): ?Transfer
+    public function safeGift(Wallet $to, ProductInterface $product, bool $force = false): ?Transfer
     {
         try {
             return $this->gift($to, $product, $force);
@@ -55,7 +55,7 @@ trait HasGift
      * @throws TransactionFailedException
      * @throws ExceptionInterface
      */
-    public function gift(Wallet $to, Product $product, bool $force = false): Transfer
+    public function gift(Wallet $to, ProductInterface $product, bool $force = false): Transfer
     {
         return app(AtomicServiceInterface::class)->block($this, function () use ($to, $product, $force): Transfer {
             $mathService = app(MathServiceInterface::class);
@@ -103,7 +103,7 @@ trait HasGift
      * @throws TransactionFailedException
      * @throws ExceptionInterface
      */
-    public function forceGift(Wallet $to, Product $product): Transfer
+    public function forceGift(Wallet $to, ProductInterface $product): Transfer
     {
         return $this->gift($to, $product, true);
     }

--- a/tests/Infra/Models/Item.php
+++ b/tests/Infra/Models/Item.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Bavix\Wallet\Test\Infra\Models;
 
 use Bavix\Wallet\Interfaces\Customer;
-use Bavix\Wallet\Interfaces\Product;
+use Bavix\Wallet\Interfaces\ProductLimitedInterface;
 use Bavix\Wallet\Models\Transfer;
 use Bavix\Wallet\Models\Wallet;
 use Bavix\Wallet\Services\CastService;
@@ -20,7 +20,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
  * @property int    $quantity
  * @property int    $price
  */
-class Item extends Model implements Product
+class Item extends Model implements ProductLimitedInterface
 {
     use HasWallet;
 


### PR DESCRIPTION
I have seen a lot of projects implemented on this package and most use the shopping functionality for endless products. There was a need to split the product interface into two (limited product and unlimited product). Usually, unlimited is understood as the internal currency of the site, services and other rapidly renewable goods.