### PR TITLE
[9.x] Changing the logic of funds transfers

### DIFF
--- a/src/Services/PrepareService.php
+++ b/src/Services/PrepareService.php
@@ -97,11 +97,11 @@ final class PrepareService implements PrepareServiceInterface
 
         return $this->transferLazyDtoAssembler->create(
             $from,
-            $to,
+            $toWallet,
             $discount,
             $fee,
             $this->withdraw($from, $withdrawAmount, $withdrawOption->getMeta(), $withdrawOption->isConfirmed()),
-            $this->deposit($to, $depositAmount, $depositOption->getMeta(), $depositOption->isConfirmed()),
+            $this->deposit($toWallet, $depositAmount, $depositOption->getMeta(), $depositOption->isConfirmed()),
             $status
         );
     }

--- a/src/Services/PurchaseService.php
+++ b/src/Services/PurchaseService.php
@@ -7,7 +7,6 @@ namespace Bavix\Wallet\Services;
 use Bavix\Wallet\Interfaces\Customer;
 use Bavix\Wallet\Internal\Dto\BasketDtoInterface;
 use Bavix\Wallet\Models\Transfer;
-use Illuminate\Database\Eloquent\Model;
 
 final class PurchaseService implements PurchaseServiceInterface
 {

--- a/src/Traits/HasGift.php
+++ b/src/Traits/HasGift.php
@@ -84,7 +84,7 @@ trait HasGift
                 $withdraw->getKey(),
                 Transfer::STATUS_GIFT,
                 $castService->getWallet($to),
-                $castService->getModel($product),
+                $castService->getWallet($product),
                 $discount,
                 $fee
             );

--- a/tests/Infra/Models/Item.php
+++ b/tests/Infra/Models/Item.php
@@ -9,6 +9,7 @@ use Bavix\Wallet\Interfaces\ProductLimitedInterface;
 use Bavix\Wallet\Models\Transfer;
 use Bavix\Wallet\Models\Wallet;
 use Bavix\Wallet\Services\CastService;
+use Bavix\Wallet\Services\CastServiceInterface;
 use Bavix\Wallet\Traits\HasWallet;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
@@ -55,7 +56,8 @@ class Item extends Model implements ProductLimitedInterface
      */
     public function boughtGoods(array $walletIds): MorphMany
     {
-        return $this
+        return app(CastServiceInterface::class)
+            ->getWallet($this)
             ->morphMany(config('wallet.transfer.model', Transfer::class), 'to')
             ->where('status', Transfer::STATUS_PAID)
             ->where('from_type', config('wallet.wallet.model', Wallet::class))

--- a/tests/Units/Domain/DiscountTaxTest.php
+++ b/tests/Units/Domain/DiscountTaxTest.php
@@ -65,12 +65,13 @@ final class DiscountTaxTest extends TestCase
 
         self::assertInstanceOf(Buyer::class, $transfer->from->holder);
         self::assertInstanceOf(Wallet::class, $transfer->from);
-        self::assertInstanceOf(Item::class, $transfer->to);
+        self::assertInstanceOf(Item::class, $transfer->to->holder);
         self::assertInstanceOf(Wallet::class, $transfer->to->wallet);
 
         self::assertSame($buyer->wallet->getKey(), $transfer->from->getKey());
         self::assertSame($buyer->getKey(), $transfer->from->holder->getKey());
-        self::assertSame($product->getKey(), $transfer->to->getKey());
+        self::assertSame($product->wallet->getKey(), $transfer->to->getKey());
+        self::assertSame($product->getKey(), $transfer->to->holder->getKey());
     }
 
     public function testRefundPersonalDiscountAndTax(): void

--- a/tests/Units/Domain/DiscountTest.php
+++ b/tests/Units/Domain/DiscountTest.php
@@ -60,12 +60,13 @@ final class DiscountTest extends TestCase
 
         self::assertInstanceOf(Buyer::class, $transfer->from->holder);
         self::assertInstanceOf(Wallet::class, $transfer->from);
-        self::assertInstanceOf(Item::class, $transfer->to);
+        self::assertInstanceOf(Item::class, $transfer->to->holder);
         self::assertInstanceOf(Wallet::class, $transfer->to->wallet);
 
         self::assertSame($buyer->wallet->getKey(), $transfer->from->getKey());
         self::assertSame($buyer->getKey(), $transfer->from->holder->getKey());
-        self::assertSame($product->getKey(), $transfer->to->getKey());
+        self::assertSame($product->wallet->getKey(), $transfer->to->getKey());
+        self::assertSame($product->getKey(), $transfer->to->holder->getKey());
     }
 
     public function testItemTransactions(): void

--- a/tests/Units/Domain/MultiWalletTest.php
+++ b/tests/Units/Domain/MultiWalletTest.php
@@ -500,7 +500,7 @@ final class MultiWalletTest extends TestCase
         self::assertInstanceOf(UserMulti::class, $paidTransfer->withdraw->payable);
         self::assertSame($user->getKey(), $paidTransfer->withdraw->payable->getKey());
         self::assertSame($transfer->from->id, $a->id);
-        self::assertSame($transfer->to->id, $product->id);
+        self::assertSame($transfer->to->id, $product->wallet->id);
         self::assertSame($transfer->status, Transfer::STATUS_PAID);
         self::assertSame($a->balanceInt, 0);
         self::assertSame($product->balanceInt, $product->getAmountProduct($a));
@@ -512,7 +512,7 @@ final class MultiWalletTest extends TestCase
         self::assertInstanceOf(UserMulti::class, $paidTransfer->withdraw->payable);
         self::assertSame($user->getKey(), $paidTransfer->withdraw->payable->getKey());
         self::assertSame($transfer->from->id, $b->id);
-        self::assertSame($transfer->to->id, $product->id);
+        self::assertSame($transfer->to->id, $product->wallet->id);
         self::assertSame($transfer->status, Transfer::STATUS_PAID);
         self::assertSame($b->balanceInt, 0);
         self::assertSame($product->balanceInt, $product->getAmountProduct($b) * 2);

--- a/tests/Units/Domain/ProductTest.php
+++ b/tests/Units/Domain/ProductTest.php
@@ -60,12 +60,13 @@ final class ProductTest extends TestCase
 
         self::assertInstanceOf(Buyer::class, $transfer->from->holder);
         self::assertInstanceOf(Wallet::class, $transfer->from);
-        self::assertInstanceOf(Item::class, $transfer->to);
+        self::assertInstanceOf(Item::class, $transfer->to->holder);
         self::assertInstanceOf(Wallet::class, $transfer->to->wallet);
 
         self::assertSame($buyer->wallet->getKey(), $transfer->from->getKey());
         self::assertSame($buyer->getKey(), $transfer->from->holder->getKey());
-        self::assertSame($product->getKey(), $transfer->to->getKey());
+        self::assertSame($product->wallet->getKey(), $transfer->to->getKey());
+        self::assertSame($product->getKey(), $transfer->to->holder->getKey());
 
         self::assertSame(0, $buyer->balanceInt);
         self::assertNull($buyer->safePay($product));


### PR DESCRIPTION
An old, incorrect architectural decision prevents us from adding full support for uuid. Unfortunately, I can no longer maintain backward compatibility in this part.

As part of this pull request, a migration team will be developed for your projects. Also, I will write documentation on usage.

And now to the problem. At the very beginning of the development of the package, it was possible to work with only one wallet, and later the ability to create many was added. Users asked for transfers between wallets and I implemented them.

Now if you make a transfer to a user, then the recipient will be the user. And here is an example:
```php
$transfer = $user1->transfer($user2, 500);
assert($transfer->from instance Wallet); // true
assert($transfer->to instance Wallet); // false
```

And here is the problem itself, in relation to "to" the wallet model should be architecturally written. After accepting this pull request, this statement will be correct.
```php
$transfer = $user1->transfer($user2, 500);
assert($transfer->from instance Wallet); // true
assert($transfer->to instance Wallet); // true
```

Previously, this behavior could only be achieved in this way:
```php
$transfer = $user1->transfer($user2->wallet, 500);
assert($transfer->from instance Wallet); // true
assert($transfer->to instance Wallet); // true
```

Because of what there was a different behavior in payments.