### PR TITLE
Fix laravel-ide-helper generate:model

### DIFF
--- a/src/Traits/HasWallet.php
+++ b/src/Traits/HasWallet.php
@@ -81,7 +81,7 @@ trait HasWallet
     public function walletTransactions(): HasMany
     {
         return app(CastServiceInterface::class)
-            ->getWallet($this, !is_null($this->id))
+            ->getWallet($this, false)
             ->hasMany(config('wallet.transaction.model', Transaction::class), 'wallet_id')
         ;
     }

--- a/src/Traits/HasWallet.php
+++ b/src/Traits/HasWallet.php
@@ -81,7 +81,7 @@ trait HasWallet
     public function walletTransactions(): HasMany
     {
         return app(CastServiceInterface::class)
-            ->getWallet($this)
+            ->getWallet($this, !is_null($this->id))
             ->hasMany(config('wallet.transaction.model', Transaction::class), 'wallet_id')
         ;
     }


### PR DESCRIPTION
This PR is attempt to fix https://github.com/bavix/laravel-wallet/issues/516, as on post https://github.com/bavix/laravel-wallet/issues/516#issuecomment-1157715295 pointed out, it already provide the arg to not execute save.

so we can leverage that, if user id is not present, we set the method `getWallet` argument `$save` as false.

this will ensure, when authenticated user id will auto save, 
when execute without any authentication for this instance, laravel-ide-helper would not execute save

```bash
➜  laravel-wallet git:(master) ✗ phpunit --stop-on-failure
PHPUnit 9.5.20 #StandWithUkraine

Runtime:       PHP 8.0.8
Configuration: /Users/keatliang/Downloads/laravel-wallet/phpunit.xml
Warning:       No code coverage driver available

...............................................................  63 / 193 ( 32%)
............................................................... 126 / 193 ( 65%)
............................................................... 189 / 193 ( 97%)
....                                                            193 / 193 (100%)

Time: 00:06.076, Memory: 56.00 MB

OK (193 tests, 1653 assertions)

```

