### PR TITLE
Change CacheManager to CacheFactory for compatibility with Lumen

### DIFF
--- a/src/Internal/Service/LockService.php
+++ b/src/Internal/Service/LockService.php
@@ -6,7 +6,7 @@ namespace Bavix\Wallet\Internal\Service;
 
 use Bavix\Wallet\Internal\Exceptions\ExceptionInterface;
 use Bavix\Wallet\Internal\Exceptions\LockProviderNotFoundException;
-use Illuminate\Cache\CacheManager;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
@@ -17,10 +17,10 @@ final class LockService implements LockServiceInterface
 
     private int $seconds;
 
-    public function __construct(CacheManager $cacheManager, ConfigRepository $config)
+    public function __construct(CacheFactory $cacheFactory, ConfigRepository $config)
     {
         $this->seconds = (int) $config->get('wallet.lock.seconds', 1);
-        $this->cache = $cacheManager->driver($config->get('wallet.lock.driver', 'array'));
+        $this->cache = $cacheFactory->store($config->get('wallet.lock.driver', 'array'));
     }
 
     /**

--- a/src/WalletServiceProvider.php
+++ b/src/WalletServiceProvider.php
@@ -97,7 +97,7 @@ use Bavix\Wallet\Services\WalletServiceInterface;
 use function config;
 use function dirname;
 use function function_exists;
-use Illuminate\Cache\CacheManager;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Support\ServiceProvider;
 
 final class WalletServiceProvider extends ServiceProvider
@@ -221,8 +221,8 @@ final class WalletServiceProvider extends ServiceProvider
                 'storageService' => $this->app->make(
                     StorageServiceInterface::class,
                     [
-                        'cacheRepository' => $this->app->make(CacheManager::class)
-                            ->driver($cache['driver'] ?? 'array'),
+                        'cacheRepository' => $this->app->make(CacheFactory::class)
+                            ->store($cache['driver'] ?? 'array'),
                     ],
                 ),
             ]
@@ -234,8 +234,8 @@ final class WalletServiceProvider extends ServiceProvider
                 'storageService' => $this->app->make(
                     StorageServiceInterface::class,
                     [
-                        'cacheRepository' => $this->app->make(CacheManager::class)
-                            ->driver('array'),
+                        'cacheRepository' => $this->app->make(CacheFactory::class)
+                            ->store('array'),
                     ],
                 ),
             ]


### PR DESCRIPTION
This PR fixes the following error when running on lumen: `Unresolvable dependency resolving [Parameter #0 [ <required> $app ]] in class Illuminate\Cache\CacheManager`

This is based on the same fix applied to laravel/doctrine when they had this exact issue. (https://github.com/laravel-doctrine/orm/commit/103c2276bed4300347d9cdb4a96d22082712a1fc)