### PR TITLE
Fix transaction amount_float mutator

### DIFF
--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -90,7 +90,7 @@ class Transaction extends Model
             ->decimal_places;
         $decimalPlaces = $math->powTen($decimalPlacesValue);
 
-        return $math->div($this->amount, $decimalPlaces);
+        return $math->div($this->amount, $decimalPlaces, $decimalPlacesValue);
     }
 
     public function setAmountFloatAttribute(float|int|string $amount): void

--- a/src/Traits/HasWallet.php
+++ b/src/Traits/HasWallet.php
@@ -81,7 +81,7 @@ trait HasWallet
     public function walletTransactions(): HasMany
     {
         return app(CastServiceInterface::class)
-            ->getWallet($this, !is_null($this->id))
+            ->getWallet($this, false)
             ->hasMany(config('wallet.transaction.model', Transaction::class), 'wallet_id')
         ;
     }

--- a/src/Traits/HasWallet.php
+++ b/src/Traits/HasWallet.php
@@ -81,7 +81,7 @@ trait HasWallet
     public function walletTransactions(): HasMany
     {
         return app(CastServiceInterface::class)
-            ->getWallet($this)
+            ->getWallet($this, !is_null($this->id))
             ->hasMany(config('wallet.transaction.model', Transaction::class), 'wallet_id')
         ;
     }

--- a/tests/Units/Domain/TransactionAmountFloatAccessorTest.php
+++ b/tests/Units/Domain/TransactionAmountFloatAccessorTest.php
@@ -32,7 +32,11 @@ final class TransactionAmountFloatAccessorTest extends TestCase
         $twoDecimalTransaction = $twoDecimalWallet->depositFloat($amountTwoDecimal);
 
         self::assertNotNull($twoDecimalTransaction);
-        self::assertSame($amountTwoDecimal, (float) $twoDecimalTransaction->amountFloat, 'amount float is same decimal places');
+        self::assertSame(
+            $amountTwoDecimal,
+            (float) $twoDecimalTransaction->amountFloat,
+            'amount float is same decimal places'
+        );
 
         // four decimal
         $fourDecimalWallet = $user->createWallet([
@@ -45,6 +49,10 @@ final class TransactionAmountFloatAccessorTest extends TestCase
         $fourDecimalTransaction = $fourDecimalWallet->depositFloat($amountFourDecimal);
 
         self::assertNotNull($fourDecimalTransaction);
-        self::assertSame($amountFourDecimal, (float) $fourDecimalTransaction->amountFloat, 'amount float is same decimal places');
+        self::assertSame(
+            $amountFourDecimal,
+            (float) $fourDecimalTransaction->amountFloat,
+            'amount float is same decimal places'
+        );
     }
 }

--- a/tests/Units/Domain/TransactionAmountFloatAccessorTest.php
+++ b/tests/Units/Domain/TransactionAmountFloatAccessorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bavix\Wallet\Test\Units\Domain;
+
+use Bavix\Wallet\Test\Infra\Factories\UserMultiFactory;
+use Bavix\Wallet\Test\Infra\Models\UserMulti;
+use Bavix\Wallet\Test\Infra\TestCase;
+
+/**
+ * @internal
+ */
+final class TransactionAmountFloatAccessorTest extends TestCase
+{
+    /**
+     * @see https://github.com/bavix/laravel-wallet/pull/533
+     */
+    public function testTransactionAmountFloatAccessor(): void
+    {
+        /** @var UserMulti $user */
+        $user = UserMultiFactory::new()->create();
+
+        // two decimal
+        $twoDecimalWallet = $user->createWallet([
+            'name' => '2 Floating point',
+            'slug' => '2-floating-point',
+            'decimal_places' => 2,
+        ]);
+
+        $amountTwoDecimal = 1.11;
+        $twoDecimalTransaction = $twoDecimalWallet->depositFloat($amountTwoDecimal);
+
+        self::assertNotNull($twoDecimalTransaction);
+        self::assertSame($amountTwoDecimal, (float) $twoDecimalTransaction->amountFloat, 'amount float is same decimal places');
+
+        // four decimal
+        $fourDecimalWallet = $user->createWallet([
+            'name' => '4 Floating point',
+            'slug' => '4-floating-point',
+            'decimal_places' => 4,
+        ]);
+
+        $amountFourDecimal = 1.1111;
+        $fourDecimalTransaction = $fourDecimalWallet->depositFloat($amountFourDecimal);
+
+        self::assertNotNull($fourDecimalTransaction);
+        self::assertSame($amountFourDecimal, (float) $fourDecimalTransaction->amountFloat, 'amount float is same decimal places');
+    }
+}


### PR DESCRIPTION

I have notice the mutator on the transaction model display somewhat funky. 

example i had the wallet set to 4 decimal precision, when access with `$model->amount_float`

i had `"0.0120000000000000000000000000000000000000000000000000000000000000"` as result

when i made changes above (on PR) it display correctly `"0.0120"`