### PR TITLE
[9.2] Allow to use atomic service

### DIFF
--- a/src/Services/AssistantServiceInterface.php
+++ b/src/Services/AssistantServiceInterface.php
@@ -12,6 +12,8 @@ use Bavix\Wallet\Internal\Dto\TransferDtoInterface;
 interface AssistantServiceInterface
 {
     /**
+     * Helps to quickly extract the uuid from an object.
+     *
      * @param non-empty-array<array-key, TransactionDtoInterface|TransferDtoInterface> $objects
      *
      * @return non-empty-array<array-key, string>
@@ -19,6 +21,8 @@ interface AssistantServiceInterface
     public function getUuids(array $objects): array;
 
     /**
+     * Helps to quickly calculate the amount.
+     *
      * @param non-empty-array<TransactionDtoInterface> $transactions
      *
      * @return array<int, string>
@@ -26,6 +30,8 @@ interface AssistantServiceInterface
     public function getSums(array $transactions): array;
 
     /**
+     * Helps to get cart meta data for a product.
+     *
      * @return array<mixed>|null
      */
     public function getMeta(BasketDtoInterface $basketDto, ProductInterface $product): ?array;

--- a/src/Services/AtmServiceInterface.php
+++ b/src/Services/AtmServiceInterface.php
@@ -12,6 +12,8 @@ use Bavix\Wallet\Models\Transfer;
 interface AtmServiceInterface
 {
     /**
+     * Helps to get to create a bunch of transaction objects.
+     *
      * @param non-empty-array<array-key, TransactionDtoInterface> $objects
      *
      * @return non-empty-array<string, Transaction>
@@ -19,6 +21,8 @@ interface AtmServiceInterface
     public function makeTransactions(array $objects): array;
 
     /**
+     * Helps to get to create a bunch of transfer objects.
+     *
      * @param non-empty-array<array-key, TransferDtoInterface> $objects
      *
      * @return non-empty-array<string, Transfer>

--- a/src/Services/AtomicServiceInterface.php
+++ b/src/Services/AtomicServiceInterface.php
@@ -13,6 +13,8 @@ use Illuminate\Database\RecordsNotFoundException;
 interface AtomicServiceInterface
 {
     /**
+     * The method atomically locks the transaction for other concurrent requests.
+     *
      * @template T
      * @param callable(): T $callback
      * @return T
@@ -23,4 +25,20 @@ interface AtomicServiceInterface
      * @throws ExceptionInterface
      */
     public function block(Wallet $object, callable $callback): mixed;
+
+    /**
+     * Use when you need to atomically change a lot of wallets and atomic in its pure form is not suitable. Use with
+     * caution, generates N requests to the lock service.
+     *
+     * @template T
+     * @param non-empty-array<Wallet> $objects
+     * @param callable(): T $callback
+     * @return T
+     *
+     * @throws LockProviderNotFoundException
+     * @throws RecordsNotFoundException
+     * @throws TransactionFailedException
+     * @throws ExceptionInterface
+     */
+    public function blocks(array $objects, callable $callback): mixed;
 }

--- a/src/Services/BasketServiceInterface.php
+++ b/src/Services/BasketServiceInterface.php
@@ -8,5 +8,8 @@ use Bavix\Wallet\Internal\Dto\AvailabilityDtoInterface;
 
 interface BasketServiceInterface
 {
+    /**
+     * A quick way to check stock. Able to check in batches, necessary for quick payments.
+     */
     public function availability(AvailabilityDtoInterface $availabilityDto): bool;
 }

--- a/src/Services/EagerLoaderServiceInterface.php
+++ b/src/Services/EagerLoaderServiceInterface.php
@@ -6,6 +6,9 @@ namespace Bavix\Wallet\Services;
 
 use Bavix\Wallet\Internal\Dto\BasketDtoInterface;
 
+/**
+ * Ad hoc solution... Needed for internal purposes only. Helps to optimize greedy queries inside laravel.
+ */
 interface EagerLoaderServiceInterface
 {
     public function loadWalletsByBasket(BasketDtoInterface $basketDto): void;

--- a/src/Services/ExchangeServiceInterface.php
+++ b/src/Services/ExchangeServiceInterface.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Bavix\Wallet\Services;
 
+/**
+ * Currency exchange contract between wallets.
+ */
 interface ExchangeServiceInterface
 {
+    /**
+     * Currency conversion method.
+     */
     public function convertTo(string $fromCurrency, string $toCurrency, float|int|string $amount): string;
 }

--- a/src/Traits/CanExchange.php
+++ b/src/Traits/CanExchange.php
@@ -75,7 +75,7 @@ trait CanExchange
             $fee = $taxService->getFee($to, $amount);
             $rate = app(ExchangeServiceInterface::class)->convertTo(
                 $castService->getWallet($this)
-                    ->currency,
+                    ->getCurrencyAttribute(),
                 $castService->getWallet($to)
                     ->currency,
                 1

--- a/tests/Units/Domain/CartTest.php
+++ b/tests/Units/Domain/CartTest.php
@@ -26,6 +26,29 @@ use function count;
  */
 final class CartTest extends TestCase
 {
+    public function testCartClone(): void
+    {
+        /** @var ItemMeta $product */
+        $product = ItemMetaFactory::new()->create([
+            'quantity' => 1,
+        ]);
+
+        $cart = app(Cart::class);
+
+        $cartWithItems = $cart->withItems([$product]);
+        $cartWithMeta = $cart->withMeta([
+            'product_id' => $product->getKey(),
+        ]);
+
+        self::assertCount(0, $cart->getItems());
+        self::assertCount(1, $cartWithItems->getItems());
+
+        self::assertSame([], $cart->getMeta());
+        self::assertSame([
+            'product_id' => $product->getKey(),
+        ], $cartWithMeta->getMeta());
+    }
+
     public function testCartMeta(): void
     {
         /**

--- a/tests/Units/Domain/WalletFloatTest.php
+++ b/tests/Units/Domain/WalletFloatTest.php
@@ -197,7 +197,7 @@ final class WalletFloatTest extends TestCase
 
         $transaction = $user->withdrawFloat(2556.72);
         self::assertSame($transaction->amountInt, -255672);
-        self::assertSame((float) $transaction->amountFloat, -2556.72);
+        self::assertSame((float) $transaction->getAmountFloatAttribute(), -2556.72);
         self::assertSame($transaction->type, Transaction::TYPE_WITHDRAW);
 
         self::assertSame($user->balanceInt, 1_000_000 - 255672);

--- a/tests/Units/Service/AtomicServiceTest.php
+++ b/tests/Units/Service/AtomicServiceTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bavix\Wallet\Test\Units\Service;
+
+use Bavix\Wallet\Services\AtomicServiceInterface;
+use Bavix\Wallet\Test\Infra\Factories\BuyerFactory;
+use Bavix\Wallet\Test\Infra\Models\Buyer;
+use Bavix\Wallet\Test\Infra\TestCase;
+
+/**
+ * @internal
+ */
+final class AtomicServiceTest extends TestCase
+{
+    public function testBlock(): void
+    {
+        $atomic = app(AtomicServiceInterface::class);
+
+        /** @var Buyer $user1 */
+        /** @var Buyer $user2 */
+        [$user1, $user2] = BuyerFactory::times(2)->create();
+
+        $user1->deposit(1000);
+
+        $atomic->blocks(
+            [$user1->wallet, $user2->wallet],
+            fn () => collect([
+                fn () => $user1->transfer($user2, 500),
+                fn () => $user1->transfer($user2, 500),
+                fn () => $user2->transfer($user1, 500),
+            ])
+                ->map(fn ($fx) => $fx()),
+        );
+
+        self::assertSame(1, $user2->transfers()->count());
+        self::assertSame(2, $user1->transfers()->count());
+        self::assertSame(3, $user2->transactions()->count());
+        self::assertSame(4, $user1->transactions()->count());
+
+        self::assertSame(500, $user1->balanceInt);
+        self::assertSame(500, $user2->balanceInt);
+    }
+}

--- a/tests/Units/Service/SingletonTest.php
+++ b/tests/Units/Service/SingletonTest.php
@@ -50,7 +50,7 @@ final class SingletonTest extends TestCase
         );
     }
 
-    protected function getRefId(string $object): string
+    private function getRefId(string $object): string
     {
         return spl_object_hash(app($object));
     }


### PR DESCRIPTION
Extend the interface for multiple atomic operations on multiple wallets.
```php
/**
 * Use when you need to atomically change a lot of wallets and atomic in its pure form is not suitable. Use with
 * caution, generates N requests to the lock service.
 *
 * @param non-empty-array<Wallet> $objects
 *
 * @throws LockProviderNotFoundException
 * @throws RecordsNotFoundException
 * @throws TransactionFailedException
 * @throws ExceptionInterface
 */
public function blocks(array $objects, callable $callback): mixed;
```

The main message is to be able to change the balance of several wallets atomically.

```php
$this->atomicService->blocks(
    [$user1->wallet, $user2->wallet],
    fn () => collect([
        fn () => $user1->transfer($user2, 500),
        fn () => $user1->transfer($user2, 500),
        fn () => $user2->transfer($user1, 500),
    ])
        ->map(fn ($fx) => $fx()),
);
```

What have we done?
1. Blocked two wallets;
2. Transferred money from user1 to user2 (user1 -500; user2 +500);
3. Repeated the transfer operation (user1 -1000, user2 +1000);
4. And in the opposite direction (user1 -500; user2 +500);

While transfers are going on, other transactions are waiting in line and workers are accumulating. If any of the operations does not put a lock or does not perform a transfer, the entire transaction will be rolled back.

---

So what is it for in real life?

There is a limited share budget for some condition. For example, when buying a product, we give a coupon.
The coupon will be paid from a limited fund.

Somewhere in the admin panel, a promotion and a wallet with a credit limit were created.
```php
$promo = Promotion::query()->find(125); // conditionally
$promoWallet = $promo->createWallet([
    'name' => 'Credit USD',
    'slug' => 'budget-action-limited',
    'meta' => [
        'credit' => 10_000, // limited budget action
    ],
]);
```

Let's throw the interface into the service.
```php
use \Bavix\Wallet\Services\AtomicServiceInterface;

...
public function __construct(private AtomicServiceInterface $atomicService) { }
```

We block the share budget and the user's balance.
```php
$this->atomicService->blocks(
    [$user, $promoWallet],
    function () use ($user, $product, $promoWallet, $coupon) {
        $user->pay($product);
        $promoWallet->gift($user, $coupon);
    }
);
```

If the user does not have enough funds, then he will not receive a gift. If the promotion runs out of budget, the user will not be able to buy the product.