### PR TITLE
[9.2] Ability to dynamically create a wallet

### DIFF
--- a/src/Services/WalletService.php
+++ b/src/Services/WalletService.php
@@ -29,9 +29,11 @@ final class WalletService implements WalletServiceInterface
     {
         $wallet = $this->walletRepository->create(array_merge(
             config('wallet.wallet.creating', []),
-            $data,
             [
                 'uuid' => $this->uuidFactoryService->uuid4(),
+            ],
+            $data,
+            [
                 'holder_type' => $model->getMorphClass(),
                 'holder_id' => $model->getKey(),
             ]

--- a/tests/Units/Service/WalletTest.php
+++ b/tests/Units/Service/WalletTest.php
@@ -9,7 +9,9 @@ use Bavix\Wallet\Internal\Exceptions\ModelNotFoundException;
 use Bavix\Wallet\Internal\Service\UuidFactoryServiceInterface;
 use Bavix\Wallet\Services\WalletServiceInterface;
 use Bavix\Wallet\Test\Infra\Factories\BuyerFactory;
+use Bavix\Wallet\Test\Infra\Factories\UserMultiFactory;
 use Bavix\Wallet\Test\Infra\Models\Buyer;
+use Bavix\Wallet\Test\Infra\Models\UserMulti;
 use Bavix\Wallet\Test\Infra\TestCase;
 
 /**
@@ -57,6 +59,27 @@ final class WalletTest extends TestCase
         $this->expectExceptionCode(ExceptionInterface::MODEL_NOT_FOUND);
 
         app(WalletServiceInterface::class)->getById(-1);
+    }
+
+    public function testCreateWalletWithUuid(): void
+    {
+        /** @var UserMulti $user */
+        $user = UserMultiFactory::new()->create();
+
+        $uuidFactoryService = app(UuidFactoryServiceInterface::class);
+
+        /** @var string[] $uuids */
+        $uuids = array_map(static fn () => $uuidFactoryService->uuid4(), range(1, 10));
+
+        foreach ($uuids as $uuid) {
+            $user->createWallet([
+                'uuid' => $uuid,
+                'name' => md5($uuid),
+            ]);
+        }
+
+        self::assertSame(10, $user->wallets()->count());
+        self::assertSame(10, $user->wallets()->whereIn('uuid', $uuids)->count());
     }
 
     public function testGetByUuid(): void


### PR DESCRIPTION
With a large number of wallets, you want to insert into the database asynchronously (in a queue).

It becomes possible to generate a unique key in advance and give it to the frontend.

```php
$user->createWallet([
    'uuid' => $uuid,
    'name' => 'my wallet',
]);
```