### PR TITLE
[9.5] Cache query optimize. v2

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -66,6 +66,7 @@ return [
      */
     'cache' => [
         'driver' => 'array',
+        'ttl' => 24 * 3600,
     ],
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -82,7 +82,7 @@ parameters:
 
 		-
 			message: "#^Cannot call method needs\\(\\) on mixed\\.$#"
-			count: 3
+			count: 4
 			path: src/WalletServiceProvider.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46,6 +46,11 @@ parameters:
 			path: src/Internal/Service/StateService.php
 
 		-
+			message: "#^Method Bavix\\\\Wallet\\\\Internal\\\\Service\\\\StorageService\\:\\:multiGet\\(\\) should return non\\-empty\\-array\\<string, string\\> but returns array\\<string, string\\>\\.$#"
+			count: 1
+			path: src/Internal/Service/StorageService.php
+
+		-
 			message: "#^Parameter \\#1 \\$number of method Bavix\\\\Wallet\\\\Internal\\\\Service\\\\MathServiceInterface\\:\\:round\\(\\) expects float\\|int\\|string, mixed given\\.$#"
 			count: 1
 			path: src/Internal/Service/StorageService.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46,16 +46,6 @@ parameters:
 			path: src/Internal/Service/StateService.php
 
 		-
-			message: "#^Method Bavix\\\\Wallet\\\\Internal\\\\Service\\\\StorageService\\:\\:multiGet\\(\\) should return non\\-empty\\-array\\<string, string\\> but returns array\\<string, string\\>\\.$#"
-			count: 1
-			path: src/Internal/Service/StorageService.php
-
-		-
-			message: "#^Parameter \\#1 \\$number of method Bavix\\\\Wallet\\\\Internal\\\\Service\\\\MathServiceInterface\\:\\:round\\(\\) expects float\\|int\\|string, mixed given\\.$#"
-			count: 1
-			path: src/Internal/Service/StorageService.php
-
-		-
 			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Relations\\\\HasMany\\:\\:where\\(\\)\\.$#"
 			count: 1
 			path: src/Models/Wallet.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -37,11 +37,6 @@ parameters:
 
 		-
 			message: "#^Method Bavix\\\\Wallet\\\\Internal\\\\Service\\\\StateService\\:\\:get\\(\\) should return string\\|null but returns mixed\\.$#"
-			count: 2
-			path: src/Internal/Service/StateService.php
-
-		-
-			message: "#^Parameter \\#2 \\$callback of method Illuminate\\\\Contracts\\\\Cache\\\\Repository\\:\\:rememberForever\\(\\) expects Closure, mixed given\\.$#"
 			count: 1
 			path: src/Internal/Service/StateService.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.27.0@faf106e717c37b8c81721845dba9de3d8deed8ff">
+  <file src="src/Internal/Decorator/StorageServiceLockDecorator.php">
+    <InvalidReturnStatement occurrences="1"/>
+    <InvalidReturnType occurrences="1">
+      <code>array</code>
+    </InvalidReturnType>
+  </file>
+  <file src="src/Internal/Service/StorageService.php">
+    <InvalidArrayOffset occurrences="1"/>
+    <InvalidReturnStatement occurrences="1">
+      <code>$newInputs</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>non-empty-array&lt;key-of&lt;T&gt;, string&gt;</code>
+    </InvalidReturnType>
+  </file>
+  <file src="src/Services/BookkeeperService.php">
+    <InvalidReturnStatement occurrences="2">
+      <code>$this-&gt;storageService-&gt;multiGet(array_keys($wallets))</code>
+      <code>$this-&gt;storageService-&gt;multiGet(array_keys($wallets))</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>array</code>
+    </InvalidReturnType>
+  </file>
+</files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,27 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.27.0@faf106e717c37b8c81721845dba9de3d8deed8ff">
-  <file src="src/Internal/Decorator/StorageServiceLockDecorator.php">
-    <InvalidReturnStatement occurrences="1"/>
-    <InvalidReturnType occurrences="1">
-      <code>array</code>
-    </InvalidReturnType>
-  </file>
-  <file src="src/Internal/Service/StorageService.php">
-    <InvalidArrayOffset occurrences="1"/>
-    <InvalidReturnStatement occurrences="1">
-      <code>$newInputs</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>non-empty-array&lt;key-of&lt;T&gt;, string&gt;</code>
-    </InvalidReturnType>
-  </file>
-  <file src="src/Services/BookkeeperService.php">
-    <InvalidReturnStatement occurrences="2">
-      <code>$this-&gt;storageService-&gt;multiGet(array_keys($wallets))</code>
-      <code>$this-&gt;storageService-&gt;multiGet(array_keys($wallets))</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>array</code>
-    </InvalidReturnType>
-  </file>
-</files>
+<files psalm-version="4.27.0@faf106e717c37b8c81721845dba9de3d8deed8ff"/>

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,6 +5,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="src"/>

--- a/src/Internal/Decorator/StorageServiceLockDecorator.php
+++ b/src/Internal/Decorator/StorageServiceLockDecorator.php
@@ -38,7 +38,9 @@ final class StorageServiceLockDecorator implements StorageServiceInterface
 
     public function sync(string $uuid, float|int|string $value): bool
     {
-        return $this->storageService->sync($uuid, $value);
+        return $this->multiSync([
+            $uuid => $value,
+        ]);
     }
 
     /**

--- a/src/Internal/Decorator/StorageServiceLockDecorator.php
+++ b/src/Internal/Decorator/StorageServiceLockDecorator.php
@@ -88,7 +88,7 @@ final class StorageServiceLockDecorator implements StorageServiceInterface
 
     public function multiIncrease(array $inputs): array
     {
-        return $this->lockService->blocks(array_keys($inputs), function () use ($inputs) {
+        return $this->lockService->blocks(array_keys($inputs), function () use ($inputs): array {
             $multiGet = $this->multiGet(array_keys($inputs));
             $results = [];
             foreach ($multiGet as $uuid => $item) {

--- a/src/Internal/Decorator/StorageServiceLockDecorator.php
+++ b/src/Internal/Decorator/StorageServiceLockDecorator.php
@@ -33,7 +33,7 @@ final class StorageServiceLockDecorator implements StorageServiceInterface
 
     public function get(string $uuid): string
     {
-        return $this->stateService->get($uuid) ?? $this->storageService->get($uuid);
+        return current($this->multiGet([$uuid]));
     }
 
     public function sync(string $uuid, float|int|string $value): bool

--- a/src/Internal/Decorator/StorageServiceLockDecorator.php
+++ b/src/Internal/Decorator/StorageServiceLockDecorator.php
@@ -47,12 +47,9 @@ final class StorageServiceLockDecorator implements StorageServiceInterface
      */
     public function increase(string $uuid, float|int|string $value): string
     {
-        return $this->lockService->block($uuid, function () use ($uuid, $value): string {
-            $result = $this->mathService->add($this->get($uuid), $value);
-            $this->sync($uuid, $result);
-
-            return $this->mathService->round($result);
-        });
+        return current($this->multiIncrease([
+            $uuid => $value,
+        ]));
     }
 
     public function multiGet(array $uuids): array

--- a/src/Internal/Decorator/StorageServiceLockDecorator.php
+++ b/src/Internal/Decorator/StorageServiceLockDecorator.php
@@ -57,10 +57,26 @@ final class StorageServiceLockDecorator implements StorageServiceInterface
 
     public function multiGet(array $uuids): array
     {
+        $missingKeys = [];
         $results = [];
         foreach ($uuids as $uuid) {
-            $results[$uuid] = $this->get($uuid);
+            $item = $this->stateService->get($uuid);
+            if ($item === null) {
+                $missingKeys[] = $uuid;
+                continue;
+            }
+
+            $results[$uuid] = $item;
         }
+
+        if ($missingKeys !== []) {
+            $foundValues = $this->storageService->multiGet($missingKeys);
+            foreach ($foundValues as $key => $value) {
+                $results[$key] = $value;
+            }
+        }
+
+        assert($results !== []);
 
         return $results;
     }

--- a/src/Internal/Decorator/StorageServiceLockDecorator.php
+++ b/src/Internal/Decorator/StorageServiceLockDecorator.php
@@ -98,6 +98,8 @@ final class StorageServiceLockDecorator implements StorageServiceInterface
 
             $this->multiSync($results);
 
+            assert($results !== []);
+
             return $results;
         });
     }

--- a/src/Internal/Exceptions/RecordNotFoundException.php
+++ b/src/Internal/Exceptions/RecordNotFoundException.php
@@ -8,4 +8,22 @@ use UnderflowException;
 
 final class RecordNotFoundException extends UnderflowException implements UnderflowExceptionInterface
 {
+    /**
+     * @param non-empty-array<string> $missingKeys
+     */
+    public function __construct(
+        string $message,
+        int $code,
+        private array $missingKeys
+    ) {
+        parent::__construct($message, $code);
+    }
+
+    /**
+     * @return non-empty-array<string>
+     */
+    public function getMissingKeys(): array
+    {
+        return $this->missingKeys;
+    }
 }

--- a/src/Internal/Repository/WalletRepository.php
+++ b/src/Internal/Repository/WalletRepository.php
@@ -124,6 +124,8 @@ final class WalletRepository implements WalletRepositoryInterface
      */
     private function getBy(array $attributes): Wallet
     {
+        assert($attributes !== []);
+
         try {
             $wallet = $this->wallet->newQuery()
                 ->where($attributes)

--- a/src/Internal/Service/LockService.php
+++ b/src/Internal/Service/LockService.php
@@ -64,7 +64,7 @@ final class LockService implements LockServiceInterface
     {
         $callable = $callback;
         foreach ($keys as $key) {
-            if (!$this->isBlocked($key)) {
+            if (! $this->isBlocked($key)) {
                 $callable = fn () => $this->block($key, $callable);
             }
         }

--- a/src/Internal/Service/LockService.php
+++ b/src/Internal/Service/LockService.php
@@ -51,6 +51,27 @@ final class LockService implements LockServiceInterface
         }
     }
 
+    /**
+     * @template T
+     * @param string[] $keys
+     * @param callable(): T $callback
+     *
+     * @return T
+     *
+     * @throws LockProviderNotFoundException
+     */
+    public function blocks(array $keys, callable $callback): mixed
+    {
+        $callable = $callback;
+        foreach ($keys as $key) {
+            if (!$this->isBlocked($key)) {
+                $callable = fn () => $this->block($key, $callable);
+            }
+        }
+
+        return $callable();
+    }
+
     public function isBlocked(string $key): bool
     {
         return $this->lockedKeys->get(self::INNER_KEYS . $key) === true;

--- a/src/Internal/Service/LockServiceInterface.php
+++ b/src/Internal/Service/LockServiceInterface.php
@@ -18,5 +18,16 @@ interface LockServiceInterface
      */
     public function block(string $key, callable $callback): mixed;
 
+    /**
+     * @template T
+     * @param string[] $keys
+     * @param callable(): T $callback
+     *
+     * @return T
+     *
+     * @throws LockProviderNotFoundException
+     */
+    public function blocks(array $keys, callable $callback): mixed;
+
     public function isBlocked(string $key): bool;
 }

--- a/src/Internal/Service/StateService.php
+++ b/src/Internal/Service/StateService.php
@@ -51,9 +51,16 @@ final class StateService implements StateServiceInterface
         /** @var null|callable(): array<string, string> $callable */
         $callable = $this->forkCallables->pull(self::PREFIX_FORK_CALL . $uuid);
         if ($callable !== null) {
-            $this->forks->setMultiple($callable());
+            $values = [];
+            foreach ($callable() as $key => $value) {
+                $values[self::PREFIX_FORKS . $key] = $value;
+            }
 
-            return $this->get($uuid);
+            if ($values !== []) {
+                $this->forks->setMultiple($values);
+
+                return $this->get($uuid);
+            }
         }
 
         return null;

--- a/src/Internal/Service/StateServiceInterface.php
+++ b/src/Internal/Service/StateServiceInterface.php
@@ -7,9 +7,10 @@ namespace Bavix\Wallet\Internal\Service;
 interface StateServiceInterface
 {
     /**
-     * @param callable(): string $value
+     * @param string[] $uuids
+     * @param callable(): array<string, string> $value
      */
-    public function fork(string $uuid, callable $value): void;
+    public function multiFork(array $uuids, callable $value): void;
 
     public function get(string $uuid): ?string;
 

--- a/src/Internal/Service/StorageService.php
+++ b/src/Internal/Service/StorageService.php
@@ -38,7 +38,8 @@ final class StorageService implements StorageServiceInterface
         if ($value === null) {
             throw new RecordNotFoundException(
                 'The repository did not find the object',
-                ExceptionInterface::RECORD_NOT_FOUND
+                ExceptionInterface::RECORD_NOT_FOUND,
+                [$uuid]
             );
         }
 

--- a/src/Internal/Service/StorageService.php
+++ b/src/Internal/Service/StorageService.php
@@ -15,7 +15,8 @@ final class StorageService implements StorageServiceInterface
 
     public function __construct(
         private MathServiceInterface $mathService,
-        private CacheRepository $cacheRepository
+        private CacheRepository $cacheRepository,
+        private ?int $ttl
     ) {
     }
 
@@ -115,14 +116,11 @@ final class StorageService implements StorageServiceInterface
             $values[self::PREFIX . $uuid] = $this->mathService->round($value);
         }
 
-        /** @var int $ttl */
-        $ttl = config('wallet.cache.ttl');
-
         if (count($values) === 1) {
-            return $this->cacheRepository->set(key($values), current($values), $ttl);
+            return $this->cacheRepository->set(key($values), current($values), $this->ttl);
         }
 
-        return $this->cacheRepository->setMultiple($values, $ttl);
+        return $this->cacheRepository->setMultiple($values, $this->ttl);
     }
 
     /**

--- a/src/Internal/Service/StorageService.php
+++ b/src/Internal/Service/StorageService.php
@@ -80,6 +80,7 @@ final class StorageService implements StorageServiceInterface
         }
 
         $results = [];
+        /** @var array<float|int|string|null> $values */
         foreach ($values as $key => $value) {
             $uuid = $keys[$key];
             if ($value === null) {
@@ -97,6 +98,8 @@ final class StorageService implements StorageServiceInterface
                 $missingKeys
             );
         }
+
+        assert($results !== []);
 
         return $results;
     }
@@ -137,6 +140,8 @@ final class StorageService implements StorageServiceInterface
         }
 
         $this->multiSync($newInputs);
+
+        assert($newInputs !== []);
 
         return $newInputs;
     }

--- a/src/Internal/Service/StorageService.php
+++ b/src/Internal/Service/StorageService.php
@@ -68,7 +68,14 @@ final class StorageService implements StorageServiceInterface
 
         $results = [];
         $missingKeys = [];
-        $values = $this->cacheRepository->getMultiple(array_keys($keys));
+        if (count($keys) === 1) {
+            $values = [
+                key($keys) => $this->cacheRepository->get(key($keys)),
+            ];
+        } else {
+            $values = $this->cacheRepository->getMultiple(array_keys($keys));
+        }
+
         foreach ($values as $key => $value) {
             $uuid = $keys[$key];
             if ($value === null) {

--- a/src/Internal/Service/StorageService.php
+++ b/src/Internal/Service/StorageService.php
@@ -136,9 +136,10 @@ final class StorageService implements StorageServiceInterface
     public function multiIncrease(array $inputs): array
     {
         $newInputs = [];
-        $multiGet = $this->multiGet(array_keys($inputs));
-        foreach ($multiGet as $uuid => $value) {
-            $newInputs[$uuid] = $this->mathService->round($this->mathService->add($value, $inputs[$uuid]));
+        $uuids = array_keys($inputs);
+        $multiGet = $this->multiGet($uuids);
+        foreach ($uuids as $uuid) {
+            $newInputs[$uuid] = $this->mathService->round($this->mathService->add($multiGet[$uuid], $inputs[$uuid]));
         }
 
         $this->multiSync($newInputs);

--- a/src/Internal/Service/StorageService.php
+++ b/src/Internal/Service/StorageService.php
@@ -34,16 +34,7 @@ final class StorageService implements StorageServiceInterface
      */
     public function get(string $uuid): string
     {
-        $value = $this->cacheRepository->get(self::PREFIX . $uuid);
-        if ($value === null) {
-            throw new RecordNotFoundException(
-                'The repository did not find the object',
-                ExceptionInterface::RECORD_NOT_FOUND,
-                [$uuid]
-            );
-        }
-
-        return $this->mathService->round($value);
+        return current($this->multiGet([$uuid]));
     }
 
     public function sync(string $uuid, float|int|string $value): bool

--- a/src/Internal/Service/StorageService.php
+++ b/src/Internal/Service/StorageService.php
@@ -39,7 +39,7 @@ final class StorageService implements StorageServiceInterface
 
     public function sync(string $uuid, float|int|string $value): bool
     {
-        return $this->cacheRepository->forever(self::PREFIX . $uuid, $this->mathService->round($value));
+        return $this->multiSync([$uuid => $value]);
     }
 
     /**

--- a/src/Internal/Service/StorageService.php
+++ b/src/Internal/Service/StorageService.php
@@ -39,7 +39,9 @@ final class StorageService implements StorageServiceInterface
 
     public function sync(string $uuid, float|int|string $value): bool
     {
-        return $this->multiSync([$uuid => $value]);
+        return $this->multiSync([
+            $uuid => $value,
+        ]);
     }
 
     /**
@@ -47,7 +49,9 @@ final class StorageService implements StorageServiceInterface
      */
     public function increase(string $uuid, float|int|string $value): string
     {
-        return current($this->multiIncrease([$uuid => $value]));
+        return current($this->multiIncrease([
+            $uuid => $value,
+        ]));
     }
 
     /**
@@ -63,10 +67,9 @@ final class StorageService implements StorageServiceInterface
     {
         $keys = [];
         foreach ($uuids as $uuid) {
-            $keys[self::PREFIX.$uuid] = $uuid;
+            $keys[self::PREFIX . $uuid] = $uuid;
         }
 
-        $results = [];
         $missingKeys = [];
         if (count($keys) === 1) {
             $values = [
@@ -76,6 +79,7 @@ final class StorageService implements StorageServiceInterface
             $values = $this->cacheRepository->getMultiple(array_keys($keys));
         }
 
+        $results = [];
         foreach ($values as $key => $value) {
             $uuid = $keys[$key];
             if ($value === null) {
@@ -104,7 +108,7 @@ final class StorageService implements StorageServiceInterface
     {
         $values = [];
         foreach ($inputs as $uuid => $value) {
-            $values[self::PREFIX.$uuid] = $this->mathService->round($value);
+            $values[self::PREFIX . $uuid] = $this->mathService->round($value);
         }
 
         if (count($values) === 1) {

--- a/src/Internal/Service/StorageService.php
+++ b/src/Internal/Service/StorageService.php
@@ -120,18 +120,21 @@ final class StorageService implements StorageServiceInterface
      *
      * @param T $inputs
      *
-     * @return non-empty-array<value-of<T>, string>
+     * @return non-empty-array<key-of<T>, string>
      *
      * @throws LockProviderNotFoundException
      * @throws RecordNotFoundException
      */
     public function multiIncrease(array $inputs): array
     {
-        $results = [];
-        foreach ($inputs as $uuid => $value) {
-            $results[$uuid] = $this->increase($uuid, $value);
+        $newInputs = [];
+        $multiGet = $this->multiGet(array_keys($inputs));
+        foreach ($multiGet as $uuid => $value) {
+            $newInputs[$uuid] = $this->mathService->round($this->mathService->add($value, $inputs[$uuid]));
         }
 
-        return $results;
+        $this->multiSync($newInputs);
+
+        return $newInputs;
     }
 }

--- a/src/Internal/Service/StorageService.php
+++ b/src/Internal/Service/StorageService.php
@@ -72,9 +72,10 @@ final class StorageService implements StorageServiceInterface
 
         $missingKeys = [];
         if (count($keys) === 1) {
-            $values = [
-                key($keys) => $this->cacheRepository->get(key($keys)),
-            ];
+            $values = [];
+            foreach (array_keys($keys) as $key) {
+                $values[$key] = $this->cacheRepository->get($key);
+            }
         } else {
             $values = $this->cacheRepository->getMultiple(array_keys($keys));
         }
@@ -127,6 +128,7 @@ final class StorageService implements StorageServiceInterface
      * @param T $inputs
      *
      * @return non-empty-array<key-of<T>, string>
+     * @psalm-return non-empty-array<string, string>
      *
      * @throws LockProviderNotFoundException
      * @throws RecordNotFoundException

--- a/src/Internal/Service/StorageService.php
+++ b/src/Internal/Service/StorageService.php
@@ -119,7 +119,7 @@ final class StorageService implements StorageServiceInterface
             return $this->cacheRepository->forever(key($values), current($values));
         }
 
-        return $this->cacheRepository->setMultiple($values);
+        return $this->cacheRepository->setMultiple($values, 60*60);
     }
 
     /**

--- a/src/Internal/Service/StorageService.php
+++ b/src/Internal/Service/StorageService.php
@@ -107,6 +107,10 @@ final class StorageService implements StorageServiceInterface
             $values[self::PREFIX.$uuid] = $this->mathService->round($value);
         }
 
+        if (count($values) === 1) {
+            return $this->cacheRepository->forever(key($values), current($values));
+        }
+
         return $this->cacheRepository->setMultiple($values);
     }
 

--- a/src/Internal/Service/StorageService.php
+++ b/src/Internal/Service/StorageService.php
@@ -86,11 +86,12 @@ final class StorageService implements StorageServiceInterface
      */
     public function multiSync(array $inputs): bool
     {
+        $values = [];
         foreach ($inputs as $uuid => $value) {
-            $this->sync($uuid, $value);
+            $values[self::PREFIX.$uuid] = $this->mathService->round($value);
         }
 
-        return true;
+        return $this->cacheRepository->setMultiple($values);
     }
 
     /**

--- a/src/Internal/Service/StorageService.php
+++ b/src/Internal/Service/StorageService.php
@@ -115,11 +115,14 @@ final class StorageService implements StorageServiceInterface
             $values[self::PREFIX . $uuid] = $this->mathService->round($value);
         }
 
+        /** @var int $ttl */
+        $ttl = config('wallet.cache.ttl');
+
         if (count($values) === 1) {
-            return $this->cacheRepository->forever(key($values), current($values));
+            return $this->cacheRepository->set(key($values), current($values), $ttl);
         }
 
-        return $this->cacheRepository->setMultiple($values, 60 * 60);
+        return $this->cacheRepository->setMultiple($values, $ttl);
     }
 
     /**

--- a/src/Internal/Service/StorageService.php
+++ b/src/Internal/Service/StorageService.php
@@ -47,10 +47,7 @@ final class StorageService implements StorageServiceInterface
      */
     public function increase(string $uuid, float|int|string $value): string
     {
-        $result = $this->mathService->add($this->get($uuid), $value);
-        $this->sync($uuid, $this->mathService->round($result));
-
-        return $this->mathService->round($result);
+        return current($this->multiIncrease([$uuid => $value]));
     }
 
     /**

--- a/src/Internal/Service/StorageService.php
+++ b/src/Internal/Service/StorageService.php
@@ -119,7 +119,7 @@ final class StorageService implements StorageServiceInterface
             return $this->cacheRepository->forever(key($values), current($values));
         }
 
-        return $this->cacheRepository->setMultiple($values, 60*60);
+        return $this->cacheRepository->setMultiple($values, 60 * 60);
     }
 
     /**

--- a/src/Internal/Service/StorageService.php
+++ b/src/Internal/Service/StorageService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Bavix\Wallet\Internal\Service;
 
 use Bavix\Wallet\Internal\Exceptions\ExceptionInterface;
+use Bavix\Wallet\Internal\Exceptions\LockProviderNotFoundException;
 use Bavix\Wallet\Internal\Exceptions\RecordNotFoundException;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 
@@ -58,5 +59,56 @@ final class StorageService implements StorageServiceInterface
         $this->sync($uuid, $this->mathService->round($result));
 
         return $this->mathService->round($result);
+    }
+
+    /**
+     * @template T of non-empty-array<string>
+     *
+     * @param T $uuids
+     *
+     * @return non-empty-array<value-of<T>, string>
+     *
+     * @throws RecordNotFoundException
+     */
+    public function multiGet(array $uuids): array
+    {
+        $results = [];
+        foreach ($uuids as $uuid) {
+            $results[$uuid] = $this->get($uuid);
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param non-empty-array<string, float|int|string> $inputs
+     */
+    public function multiSync(array $inputs): bool
+    {
+        foreach ($inputs as $uuid => $value) {
+            $this->sync($uuid, $value);
+        }
+
+        return true;
+    }
+
+    /**
+     * @template T of non-empty-array<string, float|int|string>
+     *
+     * @param T $inputs
+     *
+     * @return non-empty-array<value-of<T>, string>
+     *
+     * @throws LockProviderNotFoundException
+     * @throws RecordNotFoundException
+     */
+    public function multiIncrease(array $inputs): array
+    {
+        $results = [];
+        foreach ($inputs as $uuid => $value) {
+            $results[$uuid] = $this->increase($uuid, $value);
+        }
+
+        return $results;
     }
 }

--- a/src/Internal/Service/StorageServiceInterface.php
+++ b/src/Internal/Service/StorageServiceInterface.php
@@ -25,4 +25,32 @@ interface StorageServiceInterface
      * @throws RecordNotFoundException
      */
     public function increase(string $uuid, float|int|string $value): string;
+
+    /**
+     * @template T of non-empty-array<string>
+     *
+     * @param T $uuids
+     *
+     * @return non-empty-array<value-of<T>, string>
+     *
+     * @throws RecordNotFoundException
+     */
+    public function multiGet(array $uuids): array;
+
+    /**
+     * @param non-empty-array<string, float|int|string> $inputs
+     */
+    public function multiSync(array $inputs): bool;
+
+    /**
+     * @template T of non-empty-array<string, float|int|string>
+     *
+     * @param T $inputs
+     *
+     * @return non-empty-array<value-of<T>, string>
+     *
+     * @throws LockProviderNotFoundException
+     * @throws RecordNotFoundException
+     */
+    public function multiIncrease(array $inputs): array;
 }

--- a/src/Internal/Service/StorageServiceInterface.php
+++ b/src/Internal/Service/StorageServiceInterface.php
@@ -48,6 +48,7 @@ interface StorageServiceInterface
      * @param T $inputs
      *
      * @return non-empty-array<key-of<T>, string>
+     * @psalm-return non-empty-array<string, string>
      *
      * @throws LockProviderNotFoundException
      * @throws RecordNotFoundException

--- a/src/Internal/Service/StorageServiceInterface.php
+++ b/src/Internal/Service/StorageServiceInterface.php
@@ -47,7 +47,7 @@ interface StorageServiceInterface
      *
      * @param T $inputs
      *
-     * @return non-empty-array<value-of<T>, string>
+     * @return non-empty-array<key-of<T>, string>
      *
      * @throws LockProviderNotFoundException
      * @throws RecordNotFoundException

--- a/src/Services/AtomicService.php
+++ b/src/Services/AtomicService.php
@@ -57,12 +57,8 @@ final class AtomicService implements AtomicServiceInterface
             return $this->databaseService->transaction($callback);
         };
 
-        foreach (array_keys($blockObjects) as $uuid) {
-            $callable = fn () => $this->lockService->block($uuid, $callable);
-        }
-
         try {
-            return $callable();
+            return $this->lockService->blocks(array_keys($blockObjects), $callable);
         } finally {
             foreach (array_keys($blockObjects) as $uuid) {
                 $this->stateService->drop($uuid);

--- a/src/Services/AtomicService.php
+++ b/src/Services/AtomicService.php
@@ -51,9 +51,11 @@ final class AtomicService implements AtomicServiceInterface
         }
 
         $callable = function () use ($blockObjects, $callback) {
-            foreach ($blockObjects as $uuid => $wallet) {
-                $this->stateService->fork($uuid, fn () => $this->bookkeeperService->amount($wallet));
-            }
+            $this->stateService->multiFork(
+                array_keys($blockObjects),
+                fn () => $this->bookkeeperService->multiAmount($blockObjects)
+            );
+
             return $this->databaseService->transaction($callback);
         };
 

--- a/src/Services/BookkeeperService.php
+++ b/src/Services/BookkeeperService.php
@@ -32,16 +32,7 @@ final class BookkeeperService implements BookkeeperServiceInterface
      */
     public function amount(Wallet $wallet): string
     {
-        try {
-            return $this->storageService->get($wallet->uuid);
-        } catch (RecordNotFoundException) {
-            $this->lockService->block(
-                $wallet->uuid,
-                fn () => $this->sync($wallet, $wallet->getOriginalBalanceAttribute()),
-            );
-        }
-
-        return $this->storageService->get($wallet->uuid);
+        return current($this->multiAmount([$wallet->uuid => $wallet]));
     }
 
     public function sync(Wallet $wallet, float|int|string $value): bool

--- a/src/Services/BookkeeperService.php
+++ b/src/Services/BookkeeperService.php
@@ -32,12 +32,16 @@ final class BookkeeperService implements BookkeeperServiceInterface
      */
     public function amount(Wallet $wallet): string
     {
-        return current($this->multiAmount([$wallet->uuid => $wallet]));
+        return current($this->multiAmount([
+            $wallet->uuid => $wallet,
+        ]));
     }
 
     public function sync(Wallet $wallet, float|int|string $value): bool
     {
-        return $this->multiSync([$wallet->uuid => $value]);
+        return $this->multiSync([
+            $wallet->uuid => $value,
+        ]);
     }
 
     /**
@@ -46,7 +50,11 @@ final class BookkeeperService implements BookkeeperServiceInterface
      */
     public function increase(Wallet $wallet, float|int|string $value): string
     {
-        return current($this->multiIncrease([$wallet->uuid => $wallet], [$wallet->uuid => $value]));
+        return current($this->multiIncrease([
+            $wallet->uuid => $wallet,
+        ], [
+            $wallet->uuid => $value,
+        ]));
     }
 
     public function multiAmount(array $wallets): array

--- a/src/Services/BookkeeperService.php
+++ b/src/Services/BookkeeperService.php
@@ -64,13 +64,6 @@ final class BookkeeperService implements BookkeeperServiceInterface
         return $this->storageService->increase($wallet->uuid, $value);
     }
 
-    /**
-     * @template T of non-empty-array<string, Wallet>
-     *
-     * @param T $wallets
-     *
-     * @return non-empty-array<key-of<T>, string>
-     */
     public function multiAmount(array $wallets): array
     {
         try {

--- a/src/Services/BookkeeperService.php
+++ b/src/Services/BookkeeperService.php
@@ -37,7 +37,7 @@ final class BookkeeperService implements BookkeeperServiceInterface
 
     public function sync(Wallet $wallet, float|int|string $value): bool
     {
-        return $this->storageService->sync($wallet->uuid, $value);
+        return $this->multiSync([$wallet->uuid => $value]);
     }
 
     /**

--- a/src/Services/BookkeeperService.php
+++ b/src/Services/BookkeeperService.php
@@ -92,11 +92,17 @@ final class BookkeeperService implements BookkeeperServiceInterface
 
     public function multiIncrease(array $wallets, array $incrementValues): array
     {
-        $result = [];
-        foreach ($incrementValues as $uuid => $incrementValue) {
-            $result[$uuid] = $this->increase($wallets[$uuid], $incrementValue);
+        try {
+            return $this->storageService->multiIncrease($incrementValues);
+        } catch (RecordNotFoundException $recordNotFoundException) {
+            $objects = [];
+            foreach ($recordNotFoundException->getMissingKeys() as $uuid) {
+                $objects[$uuid] = $wallets[$uuid];
+            }
+
+            $this->multiAmount($objects);
         }
 
-        return $result;
+        return $this->storageService->multiIncrease($incrementValues);
     }
 }

--- a/src/Services/BookkeeperService.php
+++ b/src/Services/BookkeeperService.php
@@ -23,7 +23,7 @@ final class BookkeeperService implements BookkeeperServiceInterface
 
     public function missing(Wallet $wallet): bool
     {
-        return $this->storageService->missing($this->getKey($wallet));
+        return $this->storageService->missing($wallet->uuid);
     }
 
     /**
@@ -33,20 +33,20 @@ final class BookkeeperService implements BookkeeperServiceInterface
     public function amount(Wallet $wallet): string
     {
         try {
-            return $this->storageService->get($this->getKey($wallet));
+            return $this->storageService->get($wallet->uuid);
         } catch (RecordNotFoundException) {
             $this->lockService->block(
-                $this->getKey($wallet),
+                $wallet->uuid,
                 fn () => $this->sync($wallet, $wallet->getOriginalBalanceAttribute()),
             );
         }
 
-        return $this->storageService->get($this->getKey($wallet));
+        return $this->storageService->get($wallet->uuid);
     }
 
     public function sync(Wallet $wallet, float|int|string $value): bool
     {
-        return $this->storageService->sync($this->getKey($wallet), $value);
+        return $this->storageService->sync($wallet->uuid, $value);
     }
 
     /**
@@ -56,16 +56,47 @@ final class BookkeeperService implements BookkeeperServiceInterface
     public function increase(Wallet $wallet, float|int|string $value): string
     {
         try {
-            return $this->storageService->increase($this->getKey($wallet), $value);
+            return $this->storageService->increase($wallet->uuid, $value);
         } catch (RecordNotFoundException) {
             $this->amount($wallet);
         }
 
-        return $this->storageService->increase($this->getKey($wallet), $value);
+        return $this->storageService->increase($wallet->uuid, $value);
     }
 
-    private function getKey(Wallet $wallet): string
+    /**
+     * @template T of non-empty-array<string, Wallet>
+     *
+     * @param T $wallets
+     *
+     * @return non-empty-array<key-of<T>, string>
+     */
+    public function multiAmount(array $wallets): array
     {
-        return $wallet->uuid;
+        $results = [];
+        foreach ($wallets as $uuid => $wallet) {
+            $results[$uuid] = $this->amount($wallet);
+        }
+
+        return $results;
+    }
+
+    public function multiSync(array $balances): bool
+    {
+        foreach ($balances as $uuid => $balance) {
+            $this->storageService->sync($uuid, $balance);
+        }
+
+        return true;
+    }
+
+    public function multiIncrease(array $wallets, array $incrementValues): array
+    {
+        $result = [];
+        foreach ($incrementValues as $uuid => $incrementValue) {
+            $result[$uuid] = $this->increase($wallets[$uuid], $incrementValue);
+        }
+
+        return $result;
     }
 }

--- a/src/Services/BookkeeperService.php
+++ b/src/Services/BookkeeperService.php
@@ -46,13 +46,7 @@ final class BookkeeperService implements BookkeeperServiceInterface
      */
     public function increase(Wallet $wallet, float|int|string $value): string
     {
-        try {
-            return $this->storageService->increase($wallet->uuid, $value);
-        } catch (RecordNotFoundException) {
-            $this->amount($wallet);
-        }
-
-        return $this->storageService->increase($wallet->uuid, $value);
+        return current($this->multiIncrease([$wallet->uuid => $wallet], [$wallet->uuid => $value]));
     }
 
     public function multiAmount(array $wallets): array

--- a/src/Services/BookkeeperService.php
+++ b/src/Services/BookkeeperService.php
@@ -83,11 +83,7 @@ final class BookkeeperService implements BookkeeperServiceInterface
 
     public function multiSync(array $balances): bool
     {
-        foreach ($balances as $uuid => $balance) {
-            $this->storageService->sync($uuid, $balance);
-        }
-
-        return true;
+        return $this->storageService->multiSync($balances);
     }
 
     public function multiIncrease(array $wallets, array $incrementValues): array

--- a/src/Services/BookkeeperServiceInterface.php
+++ b/src/Services/BookkeeperServiceInterface.php
@@ -25,4 +25,34 @@ interface BookkeeperServiceInterface
      * @throws RecordNotFoundException
      */
     public function increase(Wallet $wallet, float|int|string $value): string;
+
+    /**
+     * @template T of non-empty-array<string, Wallet>
+     *
+     * @param T $wallets
+     *
+     * @return non-empty-array<key-of<T>, string>
+     */
+    public function multiAmount(array $wallets): array;
+
+    /**
+     * @param non-empty-array<string, float|int|string> $balances
+     *
+     * @throws LockProviderNotFoundException
+     * @throws RecordNotFoundException
+     */
+    public function multiSync(array $balances): bool;
+
+    /**
+     * @template T of non-empty-array<string, float|int|string>
+     *
+     * @param non-empty-array<key-of<T>, Wallet> $wallets
+     * @param T $incrementValues
+     *
+     * @return non-empty-array<key-of<T>, string>
+     *
+     * @throws LockProviderNotFoundException
+     * @throws RecordNotFoundException
+     */
+    public function multiIncrease(array $wallets, array $incrementValues): array;
 }

--- a/src/Services/BookkeeperServiceInterface.php
+++ b/src/Services/BookkeeperServiceInterface.php
@@ -32,6 +32,7 @@ interface BookkeeperServiceInterface
      * @param T $wallets
      *
      * @return non-empty-array<key-of<T>, string>
+     * @psalm-return non-empty-array<string, string>
      */
     public function multiAmount(array $wallets): array;
 

--- a/src/Services/RegulatorService.php
+++ b/src/Services/RegulatorService.php
@@ -89,6 +89,7 @@ final class RegulatorService implements RegulatorServiceInterface
     public function approve(): void
     {
         try {
+            $balances = [];
             $incrementValues = [];
             foreach ($this->wallets as $wallet) {
                 $diffValue = $this->diff($wallet);
@@ -97,19 +98,15 @@ final class RegulatorService implements RegulatorServiceInterface
                 }
 
                 $incrementValues[$wallet->uuid] = $diffValue;
+                $balances[$wallet->getKey()] = $this->amount($wallet);
             }
 
-            if ($incrementValues === [] || $this->wallets === []) {
+            if ($balances === [] || $incrementValues === [] || $this->wallets === []) {
                 return;
             }
 
-            $balances = [];
-            $multiIncrease = $this->bookkeeperService->multiIncrease($this->wallets, $incrementValues);
-            foreach ($multiIncrease as $uuid => $item) {
-                $balances[$this->wallets[$uuid]->getKey()] = $item;
-            }
-
             $this->walletRepository->updateBalances($balances);
+            $multiIncrease = $this->bookkeeperService->multiIncrease($this->wallets, $incrementValues);
 
             foreach ($multiIncrease as $uuid => $balance) {
                 $wallet = $this->wallets[$uuid];

--- a/src/WalletServiceProvider.php
+++ b/src/WalletServiceProvider.php
@@ -208,6 +208,9 @@ final class WalletServiceProvider extends ServiceProvider
     private function internal(array $configure): void
     {
         $this->app->alias($configure['storage'] ?? StorageService::class, 'wallet.internal.storage');
+        $this->app->when($configure['storage'] ?? StorageService::class)
+            ->needs('$ttl')
+            ->giveConfig('wallet.cache.ttl');
 
         $this->app->singleton(ClockServiceInterface::class, $configure['clock'] ?? ClockService::class);
         $this->app->singleton(DatabaseServiceInterface::class, $configure['database'] ?? DatabaseService::class);

--- a/tests/Units/Service/BookkeeperTest.php
+++ b/tests/Units/Service/BookkeeperTest.php
@@ -46,4 +46,24 @@ final class BookkeeperTest extends TestCase
         self::assertTrue($booker->missing($buyer->wallet));
         self::assertSame('0', $booker->amount($buyer->wallet));
     }
+
+    public function testMultiIncrease(): void
+    {
+        /** @var Buyer $buyer */
+        $buyer = BuyerFactory::new()->create();
+
+        $booker = app(BookkeeperService::class);
+        self::assertSame(
+            [
+                $buyer->wallet->uuid => '5',
+            ],
+            $booker->multiIncrease([
+                $buyer->wallet->uuid => $buyer->wallet,
+            ], [
+                $buyer->wallet->uuid => 5,
+            ]),
+        );
+        self::assertTrue($booker->missing($buyer->wallet));
+        self::assertSame('0', $booker->amount($buyer->wallet));
+    }
 }

--- a/tests/Units/Service/StorageTest.php
+++ b/tests/Units/Service/StorageTest.php
@@ -44,4 +44,16 @@ final class StorageTest extends TestCase
 
         $storage->get('hello'); // record not found
     }
+
+    public function testIncreaseDecorator(): void
+    {
+        $storage = app(StorageServiceLockDecorator::class);
+
+        $storage->multiSync([
+            'hello' => 34,
+        ]);
+
+        self::assertSame('34', $storage->get('hello'));
+        self::assertSame('42', $storage->increase('hello', 8));
+    }
 }


### PR DESCRIPTION
- Redis. All requests inside the AtomicService will be executed in a transaction;
- Memcached. Requests will be combined into multiGet and multiSet. Performance boost;

---

Without config key `cache.ttl` package saves the cache forever.

For users who pushed the wallet.php configuration into their project, the application logic will remain unchanged, and for new projects ttl will be added to the default configuration.

If ttl is set to null, then you will get a "forever" cache situation. The cache lives by default for 24 hours.
```php
    'cache' => [
        'driver' => '...',
        'ttl' => 24 * 3600,
    ],
```

What problem should TTL solve? Then the "cold" data will no longer take up space in RAM.