### PR TITLE
[10.x] Remove the use of the _type field in queries. Performance

### DIFF
--- a/src/Models/Transfer.php
+++ b/src/Models/Transfer.php
@@ -7,7 +7,6 @@ namespace Bavix\Wallet\Models;
 use function config;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 /**
  * Class Transfer.
@@ -77,14 +76,14 @@ class Transfer extends Model
         return parent::getTable();
     }
 
-    public function from(): MorphTo
+    public function from(): BelongsTo
     {
-        return $this->morphTo();
+        return $this->belongsTo(Wallet::class, 'from_id');
     }
 
-    public function to(): MorphTo
+    public function to(): BelongsTo
     {
-        return $this->morphTo();
+        return $this->belongsTo(Wallet::class, 'to_id');
     }
 
     public function deposit(): BelongsTo

--- a/src/Services/PurchaseService.php
+++ b/src/Services/PurchaseService.php
@@ -43,7 +43,6 @@ final class PurchaseService implements PurchaseServiceInterface
              */
             $arrays[] = (clone $query)
                 ->with(['deposit', 'withdraw.wallet'])
-                ->where('to_type', $wallet->getMorphClass())
                 ->where('to_id', $wallet->getKey())
                 ->whereIn('status', $status)
                 ->orderBy('id', 'desc')

--- a/tests/Units/Upgrade/TransferFixTest.php
+++ b/tests/Units/Upgrade/TransferFixTest.php
@@ -6,6 +6,7 @@ namespace Bavix\Wallet\Test\Units\Upgrade;
 
 use Bavix\Wallet\Test\Infra\Factories\BuyerFactory;
 use Bavix\Wallet\Test\Infra\Models\Buyer;
+use Bavix\Wallet\Test\Infra\PackageModels\Wallet;
 use Bavix\Wallet\Test\Infra\TestCase;
 
 /**
@@ -20,10 +21,10 @@ final class TransferFixTest extends TestCase
         [$buyer1, $buyer2] = BuyerFactory::times(2)->create();
         $transfer = $buyer1->forceTransfer($buyer2, 1_000_000);
 
-        self::assertSame($buyer1->wallet->getMorphClass(), $transfer->from->getMorphClass());
+        self::assertSame(Wallet::class, $transfer->from->getMorphClass());
         self::assertSame($buyer1->wallet->getKey(), $transfer->from->getKey());
 
-        self::assertSame($buyer2->wallet->getMorphClass(), $transfer->to->getMorphClass());
+        self::assertSame(Wallet::class, $transfer->to->getMorphClass());
         self::assertSame($buyer2->wallet->getKey(), $transfer->to->getKey());
 
         $buyer1->wallet->transfers()
@@ -40,10 +41,10 @@ final class TransferFixTest extends TestCase
         $transfer->from->refresh();
         $transfer->to->refresh();
 
-        self::assertSame($buyer1->getMorphClass(), $transfer->from->getMorphClass());
+        self::assertSame($buyer1->getMorphClass(), $transfer->from_type);
         self::assertSame($buyer1->getKey(), $transfer->from->getKey());
 
-        self::assertSame($buyer2->getMorphClass(), $transfer->to->getMorphClass());
+        self::assertSame($buyer2->getMorphClass(), $transfer->to_type);
         self::assertSame($buyer2->getKey(), $transfer->to->getKey());
 
         $this->artisan('bx:transfer:fix')
@@ -51,13 +52,11 @@ final class TransferFixTest extends TestCase
         ;
 
         $transfer->refresh();
-        $transfer->from->refresh();
-        $transfer->to->refresh();
 
-        self::assertSame($buyer1->wallet->getMorphClass(), $transfer->from->getMorphClass());
+        self::assertSame(\Bavix\Wallet\Models\Wallet::class, $transfer->from_type);
         self::assertSame($buyer1->wallet->getKey(), $transfer->from->getKey());
 
-        self::assertSame($buyer2->wallet->getMorphClass(), $transfer->to->getMorphClass());
+        self::assertSame(\Bavix\Wallet\Models\Wallet::class, $transfer->to_type);
         self::assertSame($buyer2->wallet->getKey(), $transfer->to->getKey());
     }
 }


### PR DESCRIPTION
Starting from version 9.0, the package wrote the value "Wallet" in the from/to type header and used it in queries, which reduced performance. In the current PR, I want to get away from unnecessary data. The columns themselves will be removed in version 11.x