### PR TITLE
[11.x] Adding an Extra column to the transfer table 

### DIFF
--- a/database/2024_01_24_185401_add_extra_column_in_transfer.php
+++ b/database/2024_01_24_185401_add_extra_column_in_transfer.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Bavix\Wallet\Models\Transfer;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table($this->table(), static function (Blueprint $table) {
+            $table->json('extra')
+                ->nullable()
+                ->after('fee')
+            ;
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropColumns($this->table(), ['extra']);
+    }
+
+    private function table(): string
+    {
+        return (new Transfer())->getTable();
+    }
+};

--- a/phpstan.src.baseline.neon
+++ b/phpstan.src.baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Constructor in Bavix\\\\Wallet\\\\External\\\\Dto\\\\Extra has parameter \\$extra with default value\\.$#"
+			count: 1
+			path: src/External/Dto/Extra.php
+
+		-
 			message: "#^Constructor in Bavix\\\\Wallet\\\\External\\\\Dto\\\\Extra has parameter \\$uuid with default value\\.$#"
 			count: 1
 			path: src/External/Dto/Extra.php

--- a/src/External/Contracts/ExtraDtoInterface.php
+++ b/src/External/Contracts/ExtraDtoInterface.php
@@ -11,4 +11,9 @@ interface ExtraDtoInterface
     public function getWithdrawOption(): OptionDtoInterface;
 
     public function getUuid(): ?string;
+
+    /**
+     * @return array<mixed>|null
+     */
+    public function getExtra(): ?array;
 }

--- a/src/External/Dto/Extra.php
+++ b/src/External/Dto/Extra.php
@@ -16,11 +16,13 @@ final class Extra implements ExtraDtoInterface
     /**
      * @param OptionDtoInterface|array<mixed>|null $deposit
      * @param OptionDtoInterface|array<mixed>|null $withdraw
+     * @param array<mixed>|null $extra
      */
     public function __construct(
         OptionDtoInterface|array|null $deposit,
         OptionDtoInterface|array|null $withdraw,
-        private readonly ?string $uuid = null
+        private readonly ?string $uuid = null,
+        private readonly ?array $extra = null
     ) {
         $this->deposit = $deposit instanceof OptionDtoInterface ? $deposit : new Option($deposit);
         $this->withdraw = $withdraw instanceof OptionDtoInterface ? $withdraw : new Option($withdraw);
@@ -39,5 +41,13 @@ final class Extra implements ExtraDtoInterface
     public function getUuid(): ?string
     {
         return $this->uuid;
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    public function getExtra(): ?array
+    {
+        return $this->extra;
     }
 }

--- a/src/Internal/Assembler/TransferDtoAssembler.php
+++ b/src/Internal/Assembler/TransferDtoAssembler.php
@@ -18,6 +18,7 @@ final readonly class TransferDtoAssembler implements TransferDtoAssemblerInterfa
     ) {
     }
 
+    /** @param array<mixed>|null $extra */
     public function create(
         int $depositId,
         int $withdrawId,
@@ -26,7 +27,8 @@ final readonly class TransferDtoAssembler implements TransferDtoAssemblerInterfa
         Model $toModel,
         int $discount,
         string $fee,
-        ?string $uuid
+        ?string $uuid,
+        ?array $extra,
     ): TransferDtoInterface {
         return new TransferDto(
             $uuid ?? $this->uuidService->uuid4(),
@@ -37,6 +39,7 @@ final readonly class TransferDtoAssembler implements TransferDtoAssemblerInterfa
             $toModel->getKey(),
             $discount,
             $fee,
+            $extra,
             $this->clockService->now(),
             $this->clockService->now(),
         );

--- a/src/Internal/Assembler/TransferDtoAssemblerInterface.php
+++ b/src/Internal/Assembler/TransferDtoAssemblerInterface.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 
 interface TransferDtoAssemblerInterface
 {
+    /** @param array<mixed>|null $extra */
     public function create(
         int $depositId,
         int $withdrawId,
@@ -17,6 +18,7 @@ interface TransferDtoAssemblerInterface
         Model $toModel,
         int $discount,
         string $fee,
-        ?string $uuid
+        ?string $uuid,
+        ?array $extra,
     ): TransferDtoInterface;
 }

--- a/src/Internal/Assembler/TransferLazyDtoAssembler.php
+++ b/src/Internal/Assembler/TransferLazyDtoAssembler.php
@@ -11,6 +11,7 @@ use Bavix\Wallet\Internal\Dto\TransferLazyDtoInterface;
 
 final class TransferLazyDtoAssembler implements TransferLazyDtoAssemblerInterface
 {
+    /** @param array<mixed>|null $extra */
     public function create(
         Wallet $fromWallet,
         Wallet $toWallet,
@@ -19,8 +20,19 @@ final class TransferLazyDtoAssembler implements TransferLazyDtoAssemblerInterfac
         TransactionDtoInterface $withdrawDto,
         TransactionDtoInterface $depositDto,
         string $status,
-        ?string $uuid
+        ?string $uuid,
+        ?array $extra,
     ): TransferLazyDtoInterface {
-        return new TransferLazyDto($fromWallet, $toWallet, $discount, $fee, $withdrawDto, $depositDto, $status, $uuid);
+        return new TransferLazyDto(
+            $fromWallet,
+            $toWallet,
+            $discount,
+            $fee,
+            $withdrawDto,
+            $depositDto,
+            $status,
+            $uuid,
+            $extra,
+        );
     }
 }

--- a/src/Internal/Assembler/TransferLazyDtoAssemblerInterface.php
+++ b/src/Internal/Assembler/TransferLazyDtoAssemblerInterface.php
@@ -10,6 +10,7 @@ use Bavix\Wallet\Internal\Dto\TransferLazyDtoInterface;
 
 interface TransferLazyDtoAssemblerInterface
 {
+    /** @param array<mixed>|null $extra */
     public function create(
         Wallet $fromWallet,
         Wallet $toWallet,
@@ -18,6 +19,7 @@ interface TransferLazyDtoAssemblerInterface
         TransactionDtoInterface $withdrawDto,
         TransactionDtoInterface $depositDto,
         string $status,
-        ?string $uuid
+        ?string $uuid,
+        ?array $extra,
     ): TransferLazyDtoInterface;
 }

--- a/src/Internal/Dto/BasketDto.php
+++ b/src/Internal/Dto/BasketDto.php
@@ -12,10 +12,12 @@ final readonly class BasketDto implements BasketDtoInterface
     /**
      * @param non-empty-array<int|string, ItemDtoInterface> $items
      * @param array<mixed> $meta
+     * @param array<mixed>|null $extra
      */
     public function __construct(
         private array $items,
-        private array $meta
+        private array $meta,
+        private ?array $extra,
     ) {
     }
 
@@ -52,5 +54,13 @@ final readonly class BasketDto implements BasketDtoInterface
     public function items(): array
     {
         return $this->items;
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    public function extra(): ?array
+    {
+        return $this->extra;
     }
 }

--- a/src/Internal/Dto/BasketDtoInterface.php
+++ b/src/Internal/Dto/BasketDtoInterface.php
@@ -18,6 +18,11 @@ interface BasketDtoInterface extends Countable
     public function meta(): array;
 
     /**
+     * @return array<mixed>|null
+     */
+    public function extra(): ?array;
+
+    /**
      * @return non-empty-array<int|string, ItemDtoInterface>
      */
     public function items(): array;

--- a/src/Internal/Dto/TransferDto.php
+++ b/src/Internal/Dto/TransferDto.php
@@ -9,6 +9,7 @@ use DateTimeImmutable;
 /** @immutable */
 final readonly class TransferDto implements TransferDtoInterface
 {
+    /** @param array<mixed>|null $extra */
     public function __construct(
         private string $uuid,
         private int $depositId,
@@ -18,6 +19,7 @@ final readonly class TransferDto implements TransferDtoInterface
         private int $toId,
         private int $discount,
         private string $fee,
+        private ?array $extra,
         private DateTimeImmutable $createdAt,
         private DateTimeImmutable $updatedAt,
     ) {
@@ -61,6 +63,14 @@ final readonly class TransferDto implements TransferDtoInterface
     public function getFee(): string
     {
         return $this->fee;
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    public function getExtra(): ?array
+    {
+        return $this->extra;
     }
 
     public function getCreatedAt(): DateTimeImmutable

--- a/src/Internal/Dto/TransferDtoInterface.php
+++ b/src/Internal/Dto/TransferDtoInterface.php
@@ -24,6 +24,9 @@ interface TransferDtoInterface
 
     public function getFee(): string;
 
+    /** @return array<mixed>|null */
+    public function getExtra(): ?array;
+
     public function getCreatedAt(): DateTimeImmutable;
 
     public function getUpdatedAt(): DateTimeImmutable;

--- a/src/Internal/Dto/TransferLazyDto.php
+++ b/src/Internal/Dto/TransferLazyDto.php
@@ -9,6 +9,9 @@ use Bavix\Wallet\Interfaces\Wallet;
 /** @immutable */
 final readonly class TransferLazyDto implements TransferLazyDtoInterface
 {
+    /**
+     * @param array<mixed>|null $extra
+     */
     public function __construct(
         private Wallet $fromWallet,
         private Wallet $toWallet,
@@ -17,7 +20,8 @@ final readonly class TransferLazyDto implements TransferLazyDtoInterface
         private TransactionDtoInterface $withdrawDto,
         private TransactionDtoInterface $depositDto,
         private string $status,
-        private ?string $uuid
+        private ?string $uuid,
+        private ?array $extra,
     ) {
     }
 
@@ -59,5 +63,13 @@ final readonly class TransferLazyDto implements TransferLazyDtoInterface
     public function getUuid(): ?string
     {
         return $this->uuid;
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    public function getExtra(): ?array
+    {
+        return $this->extra;
     }
 }

--- a/src/Internal/Dto/TransferLazyDtoInterface.php
+++ b/src/Internal/Dto/TransferLazyDtoInterface.php
@@ -23,4 +23,7 @@ interface TransferLazyDtoInterface
     public function getStatus(): string;
 
     public function getUuid(): ?string;
+
+    /** @return array<mixed>|null */
+    public function getExtra(): ?array;
 }

--- a/src/Internal/Transform/TransferDtoTransformer.php
+++ b/src/Internal/Transform/TransferDtoTransformer.php
@@ -19,6 +19,7 @@ final class TransferDtoTransformer implements TransferDtoTransformerInterface
             'to_id' => $dto->getToId(),
             'discount' => $dto->getDiscount(),
             'fee' => $dto->getFee(),
+            'extra' => $dto->getExtra(),
             'created_at' => $dto->getCreatedAt(),
             'updated_at' => $dto->getUpdatedAt(),
         ];

--- a/src/Internal/Transform/TransferDtoTransformerInterface.php
+++ b/src/Internal/Transform/TransferDtoTransformerInterface.php
@@ -19,6 +19,7 @@ interface TransferDtoTransformerInterface
      *     to_id: int|string,
      *     discount: int,
      *     fee: string,
+     *     extra: array<mixed>|null,
      *     created_at: DateTimeImmutable,
      *     updated_at: DateTimeImmutable,
      * }

--- a/src/Models/Transfer.php
+++ b/src/Models/Transfer.php
@@ -59,6 +59,7 @@ class Transfer extends Model
         'to_id',
         'uuid',
         'fee',
+        'extra',
         'created_at',
         'updated_at',
     ];
@@ -69,6 +70,7 @@ class Transfer extends Model
     protected $casts = [
         'deposit_id' => 'int',
         'withdraw_id' => 'int',
+        'extra' => 'json',
     ];
 
     public function getTable(): string

--- a/src/Models/Transfer.php
+++ b/src/Models/Transfer.php
@@ -25,6 +25,7 @@ use function config;
  * @property int $to_id
  * @property string $uuid
  * @property string $fee
+ * @property ?array<mixed> $extra
  * @property Transaction $deposit
  * @property Transaction $withdraw
  * @property DateTimeInterface $created_at

--- a/src/Objects/Cart.php
+++ b/src/Objects/Cart.php
@@ -31,6 +31,11 @@ final class Cart implements Countable, CartInterface
      */
     private array $meta = [];
 
+    /**
+     * @var array<mixed>|null
+     */
+    private ?array $extra = null;
+
     public function __construct(
         private readonly CastServiceInterface $castService,
         private readonly MathServiceInterface $math
@@ -52,6 +57,25 @@ final class Cart implements Countable, CartInterface
     {
         $self = clone $this;
         $self->meta = $meta;
+
+        return $self;
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    public function getExtra(): ?array
+    {
+        return $this->extra;
+    }
+
+    /**
+     * @param array<mixed> $extra
+     */
+    public function withExtra(array $extra): self
+    {
+        $self = clone $this;
+        $self->extra = $extra;
 
         return $self;
     }
@@ -151,7 +175,7 @@ final class Cart implements Countable, CartInterface
             throw new CartEmptyException('Cart is empty', ExceptionInterface::CART_EMPTY);
         }
 
-        return new BasketDto($items, $this->getMeta());
+        return new BasketDto($items, $this->getMeta(), $this->getExtra());
     }
 
     private function productId(ProductInterface $product): string

--- a/src/Services/PrepareService.php
+++ b/src/Services/PrepareService.php
@@ -145,7 +145,8 @@ final readonly class PrepareService implements PrepareServiceInterface
             $withdraw,
             $deposit,
             $status,
-            $extra->getUuid()
+            $extra->getUuid(),
+            $extra->getExtra(),
         );
     }
 }

--- a/src/Services/TransferService.php
+++ b/src/Services/TransferService.php
@@ -87,6 +87,7 @@ final readonly class TransferService implements TransferServiceInterface
                     $object->getDiscount(),
                     $object->getFee(),
                     $object->getUuid(),
+                    $object->getExtra(),
                 );
 
                 $transfers[] = $transfer;

--- a/src/Traits/CanExchange.php
+++ b/src/Traits/CanExchange.php
@@ -103,7 +103,8 @@ trait CanExchange
                 $withdrawDto,
                 $depositDto,
                 Transfer::STATUS_EXCHANGE,
-                $extraDto->getUuid()
+                $extraDto->getUuid(),
+                $extraDto->getExtra()
             );
 
             $transfers = app(TransferServiceInterface::class)->apply([$transferLazyDto]);

--- a/src/Traits/HasGift.php
+++ b/src/Traits/HasGift.php
@@ -85,6 +85,7 @@ trait HasGift
                 $castService->getWallet($product),
                 $discount,
                 $fee,
+                null,
                 null
             );
 

--- a/tests/Units/Api/TransferHandlerTest.php
+++ b/tests/Units/Api/TransferHandlerTest.php
@@ -6,6 +6,7 @@ namespace Bavix\Wallet\Test\Units\Api;
 
 use Bavix\Wallet\External\Api\TransferQuery;
 use Bavix\Wallet\External\Api\TransferQueryHandlerInterface;
+use Bavix\Wallet\External\Dto\Extra;
 use Bavix\Wallet\Test\Infra\Factories\BuyerFactory;
 use Bavix\Wallet\Test\Infra\Models\Buyer;
 use Bavix\Wallet\Test\Infra\TestCase;
@@ -31,13 +32,39 @@ final class TransferHandlerTest extends TestCase
         self::assertFalse($to->wallet->exists);
 
         $transfers = $transferQueryHandler->apply([
-            new TransferQuery($from, $to, 100, null),
-            new TransferQuery($from, $to, 100, null),
-            new TransferQuery($to, $from, 50, null),
+            new TransferQuery(
+                $from,
+                $to,
+                100,
+                new Extra(
+                    null,
+                    null,
+                    '598c184c-e6d6-4fc2-9640-c1c7acb38093',
+                    ['type' => 'first'],
+                ),
+            ),
+            new TransferQuery($from, $to, 100,
+                new Extra(
+                    null,
+                    null,
+                    'f303d60d-c2de-45d0-b9ed-e1487429709a',
+                    ['type' => 'second'],
+                )),
+            new TransferQuery($to, $from, 50,
+                new Extra(
+                    null,
+                    null,
+                    '7f0175fe-99cc-4058-92c6-157f0da18243',
+                    ['type' => 'third'],
+                )),
         ]);
 
         self::assertSame(-150, $from->balanceInt);
         self::assertSame(150, $to->balanceInt);
         self::assertCount(3, $transfers);
+
+        self::assertSame(['type' => 'first'], $transfers['598c184c-e6d6-4fc2-9640-c1c7acb38093']->extra);
+        self::assertSame(['type' => 'second'], $transfers['f303d60d-c2de-45d0-b9ed-e1487429709a']->extra);
+        self::assertSame(['type' => 'third'], $transfers['7f0175fe-99cc-4058-92c6-157f0da18243']->extra);
     }
 }

--- a/tests/Units/Domain/BasketTest.php
+++ b/tests/Units/Domain/BasketTest.php
@@ -20,7 +20,7 @@ final class BasketTest extends TestCase
         $item = new Item();
         $productDto1 = new ItemDto($item, 24, null, null);
         $productDto2 = new ItemDto($item, 26, null, null);
-        $basket = new BasketDto([$productDto1, $productDto2], []);
+        $basket = new BasketDto([$productDto1, $productDto2], [], null);
 
         self::assertEmpty($basket->meta());
         self::assertSame(2, $basket->count());
@@ -39,15 +39,31 @@ final class BasketTest extends TestCase
         /** @var non-empty-array<ItemDtoInterface> $items */
         $items = [];
 
-        $basket1 = new BasketDto($items, []);
+        $basket1 = new BasketDto($items, [], null);
         self::assertEmpty($basket1->meta());
 
         $basket2 = new BasketDto($items, [
             'hello' => 'world',
-        ]);
+        ], null);
         self::assertSame([
             'hello' => 'world',
         ], $basket2->meta());
+    }
+
+    public function testExtra(): void
+    {
+        /** @var non-empty-array<ItemDtoInterface> $items */
+        $items = [];
+
+        $basket1 = new BasketDto($items, [], null);
+        self::assertNull($basket1->extra());
+
+        $basket2 = new BasketDto($items, [], [
+            'hello' => 'world',
+        ]);
+        self::assertSame([
+            'hello' => 'world',
+        ], $basket2->extra());
     }
 
     public function testEmpty(): void
@@ -55,7 +71,7 @@ final class BasketTest extends TestCase
         /** @var non-empty-array<ItemDtoInterface> $items */
         $items = [];
 
-        $basket = new BasketDto($items, []);
+        $basket = new BasketDto($items, [], null);
         self::assertEmpty($basket->items());
         self::assertEmpty($basket->meta());
         self::assertSame(0, $basket->count());

--- a/tests/Units/Domain/CartTest.php
+++ b/tests/Units/Domain/CartTest.php
@@ -37,9 +37,10 @@ final class CartTest extends TestCase
         $cart = app(Cart::class);
 
         $cartWithItems = $cart->withItems([$product]);
-        $cartWithMeta = $cart->withMeta([
-            'product_id' => $product->getKey(),
-        ]);
+        $cartWithMeta = $cart
+            ->withMeta(['product_id' => $product->getKey()])
+            ->withExtra(['products' => count($cartWithItems->getItems())])
+        ;
 
         self::assertCount(0, $cart->getItems());
         self::assertCount(1, $cartWithItems->getItems());
@@ -48,6 +49,9 @@ final class CartTest extends TestCase
         self::assertSame([
             'product_id' => $product->getKey(),
         ], $cartWithMeta->getMeta());
+        self::assertSame([
+            'products' => count($cartWithItems->getItems()),
+        ], $cartWithMeta->getExtra());
     }
 
     public function testCartMeta(): void

--- a/tests/Units/Domain/ExtraTest.php
+++ b/tests/Units/Domain/ExtraTest.php
@@ -41,6 +41,7 @@ final class ExtraTest extends TestCase
                     ],
                     false
                 ),
+                extra: ['msg' => 'hello world'],
             )
         );
 
@@ -54,6 +55,9 @@ final class ExtraTest extends TestCase
         self::assertSame([
             'type' => 'extra-withdraw',
         ], $transfer->withdraw->meta);
+        self::assertSame([
+            'msg' => 'hello world',
+        ], $transfer->extra);
     }
 
     public function testExtraTransferUuidFixed(): void


### PR DESCRIPTION
#864

Example 1:
```php
        $transfers = $transferQueryHandler->apply([
            new TransferQuery(
                $from,
                $to,
                100,
                new Extra(
                    null,
                    null,
                    '598c184c-e6d6-4fc2-9640-c1c7acb38093',
                    ['type' => 'first'],
                ),
            ),
        ]);
```

Example 2:
```php
        $transfer = $user1->transfer(
            $user2,
            500,
            new Extra(
                deposit: [
                    'type' => 'extra-deposit',
                ],
                withdraw: new Option(
                    [
                        'type' => 'extra-withdraw',
                    ],
                    false
                ),
                extra: ['msg' => 'hello world'],
            )
        );
```