### PR TITLE
[11.x] Added *FloatQuery for High performance api handles

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -174,6 +174,7 @@ parameters:
       - Api
       - Model
       - Contract
+      - ServiceInterface
 
     Api:
       - Model

--- a/src/External/Api/TransactionFloatQuery.php
+++ b/src/External/Api/TransactionFloatQuery.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bavix\Wallet\External\Api;
+
+use Bavix\Wallet\Interfaces\Wallet;
+use Bavix\Wallet\Services\CastServiceInterface;
+use Bavix\Wallet\Services\FormatterServiceInterface;
+
+final readonly class TransactionFloatQuery implements TransactionQueryInterface
+{
+    private string $amount;
+
+    /**
+     * @param self::TYPE_DEPOSIT|self::TYPE_WITHDRAW $type
+     * @param array<mixed>|null $meta
+     */
+    private function __construct(
+        private string $type,
+        private Wallet $wallet,
+        float|int|string $amount,
+        private ?array $meta,
+        private bool $confirmed,
+        private ?string $uuid
+    ) {
+        $walletModel = app(CastServiceInterface::class)->getWallet($wallet);
+
+        $this->amount = app(FormatterServiceInterface::class)
+            ->intValue($amount, $walletModel->decimal_places);
+    }
+
+    /**
+     * @param array<mixed>|null $meta
+     */
+    public static function createDeposit(
+        Wallet $wallet,
+        float|int|string $amount,
+        ?array $meta,
+        bool $confirmed = true,
+        ?string $uuid = null
+    ): self {
+        return new self(self::TYPE_DEPOSIT, $wallet, $amount, $meta, $confirmed, $uuid);
+    }
+
+    /**
+     * @param array<mixed>|null $meta
+     */
+    public static function createWithdraw(
+        Wallet $wallet,
+        float|int|string $amount,
+        ?array $meta,
+        bool $confirmed = true,
+        ?string $uuid = null
+    ): self {
+        return new self(self::TYPE_WITHDRAW, $wallet, $amount, $meta, $confirmed, $uuid);
+    }
+
+    /**
+     * @return self::TYPE_DEPOSIT|self::TYPE_WITHDRAW
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getWallet(): Wallet
+    {
+        return $this->wallet;
+    }
+
+    public function getAmount(): string
+    {
+        return $this->amount;
+    }
+
+    /**
+     * @return array<mixed>|null
+     */
+    public function getMeta(): ?array
+    {
+        return $this->meta;
+    }
+
+    public function isConfirmed(): bool
+    {
+        return $this->confirmed;
+    }
+
+    public function getUuid(): ?string
+    {
+        return $this->uuid;
+    }
+}

--- a/src/External/Api/TransferFloatQuery.php
+++ b/src/External/Api/TransferFloatQuery.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bavix\Wallet\External\Api;
+
+use Bavix\Wallet\External\Contracts\ExtraDtoInterface;
+use Bavix\Wallet\Interfaces\Wallet;
+use Bavix\Wallet\Services\CastServiceInterface;
+use Bavix\Wallet\Services\FormatterServiceInterface;
+
+final readonly class TransferFloatQuery implements TransferQueryInterface
+{
+    private string $amount;
+
+    /**
+     * @param array<mixed>|ExtraDtoInterface|null $meta
+     */
+    public function __construct(
+        private Wallet $from,
+        private Wallet $to,
+        float|int|string $amount,
+        private array|ExtraDtoInterface|null $meta
+    ) {
+        $walletModel = app(CastServiceInterface::class)->getWallet($from);
+
+        $this->amount = app(FormatterServiceInterface::class)
+            ->intValue($amount, $walletModel->decimal_places);
+    }
+
+    public function getFrom(): Wallet
+    {
+        return $this->from;
+    }
+
+    public function getTo(): Wallet
+    {
+        return $this->to;
+    }
+
+    public function getAmount(): string
+    {
+        return $this->amount;
+    }
+
+    /**
+     * @return array<mixed>|ExtraDtoInterface|null
+     */
+    public function getMeta(): array|ExtraDtoInterface|null
+    {
+        return $this->meta;
+    }
+}

--- a/tests/Units/Api/TransactionHandlerTest.php
+++ b/tests/Units/Api/TransactionHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bavix\Wallet\Test\Units\Api;
 
+use Bavix\Wallet\External\Api\TransactionFloatQuery;
 use Bavix\Wallet\External\Api\TransactionQuery;
 use Bavix\Wallet\External\Api\TransactionQueryHandlerInterface;
 use Bavix\Wallet\Test\Infra\Factories\BuyerFactory;
@@ -33,17 +34,19 @@ final class TransactionHandlerTest extends TestCase
             TransactionQuery::createDeposit($buyer, 100, null),
             TransactionQuery::createDeposit($buyer, 100, null),
             TransactionQuery::createWithdraw($buyer, 400, null),
+            TransactionFloatQuery::createDeposit($buyer, 2.00, null),
+            TransactionFloatQuery::createWithdraw($buyer, 2.00, null),
         ]);
 
         self::assertSame(1, $buyer->balanceInt);
-        self::assertCount(5, $transactions);
+        self::assertCount(7, $transactions);
 
         self::assertCount(
-            4,
+            5,
             array_filter($transactions, static fn ($t) => $t->type === Transaction::TYPE_DEPOSIT),
         );
         self::assertCount(
-            1,
+            2,
             array_filter($transactions, static fn ($t) => $t->type === Transaction::TYPE_WITHDRAW),
         );
     }

--- a/tests/Units/Api/TransferHandlerTest.php
+++ b/tests/Units/Api/TransferHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bavix\Wallet\Test\Units\Api;
 
+use Bavix\Wallet\External\Api\TransferFloatQuery;
 use Bavix\Wallet\External\Api\TransferQuery;
 use Bavix\Wallet\External\Api\TransferQueryHandlerInterface;
 use Bavix\Wallet\External\Dto\Extra;
@@ -57,14 +58,22 @@ final class TransferHandlerTest extends TestCase
                     '7f0175fe-99cc-4058-92c6-157f0da18243',
                     ['type' => 'third'],
                 )),
+            new TransferFloatQuery($to, $from, .50,
+                new Extra(
+                    null,
+                    null,
+                    '1a7326a6-dfdf-4ec8-afc4-cb21cf1f43c6',
+                    ['type' => 'fourth'],
+                )),
         ]);
 
-        self::assertSame(-150, $from->balanceInt);
-        self::assertSame(150, $to->balanceInt);
-        self::assertCount(3, $transfers);
+        self::assertSame(-100, $from->balanceInt);
+        self::assertSame(100, $to->balanceInt);
+        self::assertCount(4, $transfers);
 
         self::assertSame(['type' => 'first'], $transfers['598c184c-e6d6-4fc2-9640-c1c7acb38093']->extra);
         self::assertSame(['type' => 'second'], $transfers['f303d60d-c2de-45d0-b9ed-e1487429709a']->extra);
         self::assertSame(['type' => 'third'], $transfers['7f0175fe-99cc-4058-92c6-157f0da18243']->extra);
+        self::assertSame(['type' => 'fourth'], $transfers['1a7326a6-dfdf-4ec8-afc4-cb21cf1f43c6']->extra);
     }
 }


### PR DESCRIPTION
#857

Added a convenient contract for package users `TransferFloatQuery`.

```php
app(TransferQueryHandlerInterface::class)->apply([
	new TransferFloatQuery($from, $to, .93, null),
]);
```