### PR TITLE
Add payments relation on wallet

### DIFF
--- a/src/Models/Wallet.php
+++ b/src/Models/Wallet.php
@@ -13,6 +13,7 @@ use Bavix\Wallet\Internal\Exceptions\TransactionFailedException;
 use Bavix\Wallet\Internal\Service\MathServiceInterface;
 use Bavix\Wallet\Internal\Service\UuidFactoryServiceInterface;
 use Bavix\Wallet\Services\AtomicServiceInterface;
+use Bavix\Wallet\Services\CastServiceInterface;
 use Bavix\Wallet\Services\RegulatorServiceInterface;
 use Bavix\Wallet\Traits\CanConfirm;
 use Bavix\Wallet\Traits\CanExchange;
@@ -164,5 +165,18 @@ class Wallet extends Model implements Customer, WalletFloat, Confirmable, Exchan
     protected function initializeMorphOneWallet(): void
     {
         $this->uuid = app(UuidFactoryServiceInterface::class)->uuid4();
+    }
+
+    /**
+     * returns all the receiving transfers to this wallet.
+     *
+     * @return HasMany<Transfer>
+     */
+    public function receivedTransfers(): HasMany
+    {
+        return app(CastServiceInterface::class)
+            ->getWallet($this, false)
+            ->hasMany(config('wallet.transfer.model', Transfer::class), 'to_id')
+        ;
     }
 }

--- a/src/Traits/HasWallet.php
+++ b/src/Traits/HasWallet.php
@@ -227,18 +227,4 @@ trait HasWallet
             ->hasMany(config('wallet.transfer.model', Transfer::class), 'from_id')
         ;
     }
-
-    /**
-     * returns all the receiving transfers to this wallet.
-     *
-     * @return HasMany<Transfer>
-     */
-    public function payments(): HasMany
-    {
-        /** @var Wallet $this */
-        return app(CastServiceInterface::class)
-            ->getWallet($this, false)
-            ->hasMany(config('wallet.transfer.model', Transfer::class), 'to_id')
-        ;
-    }
 }


### PR DESCRIPTION
This adds functionality to query the database for transfers in the other direction, payments. Lookup what transfers happened from another wallet to this one.