### PR TITLE
[11.x] revert collation

### DIFF
--- a/.github/workflows/phpunits.yaml
+++ b/.github/workflows/phpunits.yaml
@@ -73,7 +73,7 @@ jobs:
           - 3306:3306
 
       mariadb:
-        image: mariadb:10.7 # https://github.com/laravel/framework/pull/48455
+        image: mariadb:10.8 # https://github.com/laravel/framework/pull/48455
         env:
           MYSQL_ROOT_PASSWORD: wallet
           MYSQL_DATABASE: wallet

--- a/.github/workflows/phpunits.yaml
+++ b/.github/workflows/phpunits.yaml
@@ -73,7 +73,7 @@ jobs:
           - 3306:3306
 
       mariadb:
-        image: mariadb:10.11 # https://github.com/laravel/framework/pull/48455
+        image: mariadb:10.10 # https://github.com/laravel/framework/pull/48455
         env:
           MYSQL_ROOT_PASSWORD: wallet
           MYSQL_DATABASE: wallet

--- a/.github/workflows/phpunits.yaml
+++ b/.github/workflows/phpunits.yaml
@@ -73,7 +73,7 @@ jobs:
           - 3306:3306
 
       mariadb:
-        image: mariadb:10.11 # https://github.com/laravel/framework/pull/48455
+        image: mariadb:10.6 # https://github.com/laravel/framework/pull/48455
         env:
           MYSQL_ROOT_PASSWORD: wallet
           MYSQL_DATABASE: wallet

--- a/.github/workflows/phpunits.yaml
+++ b/.github/workflows/phpunits.yaml
@@ -73,7 +73,7 @@ jobs:
           - 3306:3306
 
       mariadb:
-        image: mariadb:10.6 # https://github.com/laravel/framework/pull/48455
+        image: mariadb:10.7 # https://github.com/laravel/framework/pull/48455
         env:
           MYSQL_ROOT_PASSWORD: wallet
           MYSQL_DATABASE: wallet

--- a/.github/workflows/phpunits.yaml
+++ b/.github/workflows/phpunits.yaml
@@ -73,7 +73,7 @@ jobs:
           - 3306:3306
 
       mariadb:
-        image: mariadb:10.9 # https://github.com/laravel/framework/pull/48455
+        image: mariadb:10.10 # https://github.com/laravel/framework/pull/48455
         env:
           MYSQL_ROOT_PASSWORD: wallet
           MYSQL_DATABASE: wallet

--- a/.github/workflows/phpunits.yaml
+++ b/.github/workflows/phpunits.yaml
@@ -73,7 +73,7 @@ jobs:
           - 3306:3306
 
       mariadb:
-        image: mariadb:10.8 # https://github.com/laravel/framework/pull/48455
+        image: mariadb:10.9 # https://github.com/laravel/framework/pull/48455
         env:
           MYSQL_ROOT_PASSWORD: wallet
           MYSQL_DATABASE: wallet

--- a/.github/workflows/phpunits.yaml
+++ b/.github/workflows/phpunits.yaml
@@ -73,7 +73,7 @@ jobs:
           - 3306:3306
 
       mariadb:
-        image: mariadb:10.5
+        image: mariadb:10.11 # https://github.com/laravel/framework/pull/48455
         env:
           MYSQL_ROOT_PASSWORD: wallet
           MYSQL_DATABASE: wallet

--- a/.github/workflows/phpunits.yaml
+++ b/.github/workflows/phpunits.yaml
@@ -73,7 +73,7 @@ jobs:
           - 3306:3306
 
       mariadb:
-        image: mariadb:10.10 # https://github.com/laravel/framework/pull/48455
+        image: mariadb:10.11 # https://github.com/laravel/framework/pull/48455
         env:
           MYSQL_ROOT_PASSWORD: wallet
           MYSQL_DATABASE: wallet

--- a/tests/Infra/TestCase.php
+++ b/tests/Infra/TestCase.php
@@ -63,12 +63,8 @@ abstract class TestCase extends OrchestraTestCase
         $config->set('database.connections.testing.prefix', 'tests');
         $config->set('database.connections.pgsql.prefix', 'tests');
         $config->set('database.connections.mysql.prefix', 'tests');
-
-        /** @var array<string, mixed> $mysql */
-        $mysql = $config->get('database.connections.mysql');
-        $config->set('database.connections.mariadb', array_merge($mysql, [
-            'port' => 3307,
-        ]));
+        $config->set('database.connections.mariadb.prefix', 'tests');
+        $config->set('database.connections.mariadb.port', 3307);
 
         // new table name's
         $config->set('wallet.transaction.table', 'transaction');

--- a/tests/Infra/TestCase.php
+++ b/tests/Infra/TestCase.php
@@ -48,9 +48,6 @@ abstract class TestCase extends OrchestraTestCase
         $app['config']->set('wallet.transfer.model', Transfer::class);
         $app['config']->set('wallet.wallet.model', Wallet::class);
 
-        //infra
-        $app['config']->set('database.mysql.collation', 'utf8mb4_unicode_ci');
-
         return [WalletServiceProvider::class, TestServiceProvider::class];
     }
 
@@ -70,7 +67,6 @@ abstract class TestCase extends OrchestraTestCase
         /** @var array<string, mixed> $mysql */
         $mysql = $config->get('database.connections.mysql');
         $config->set('database.connections.mariadb', array_merge($mysql, [
-            'collation' => 'utf8mb4_unicode_ci',
             'port' => 3307,
         ]));
 


### PR DESCRIPTION
https://github.com/laravel/framework/pull/48455

```
Changes default collation for MySQL to utf8mb4_0900_ai_ci
Changes default collation for MariaDB to utf8mb4_uca1400_ai_ci
```