### PR TITLE
[11.x] Fix UUID Drop on migration rollback

### DIFF
--- a/database/2021_11_02_202021_update_wallets_uuid_table.php
+++ b/database/2021_11_02_202021_update_wallets_uuid_table.php
@@ -40,7 +40,12 @@ return new class() extends Migration
 
     public function down(): void
     {
-        Schema::dropColumns($this->table(), ['uuid']);
+        Schema::table($this->table(), function (Blueprint $table) {
+            if (Schema::hasColumn($this->table(), 'uuid')) {
+                $table->dropIndex('wallets_uuid_unique');
+                $table->dropColumn('uuid');
+            }
+        });
     }
 
     private function table(): string


### PR DESCRIPTION
This PR will fix the drop issue on migration rollback by removing the column `uuid` as index before it drop the column.