### PR TITLE
Revert "remove prefix for mysql/mariadb"

### DIFF
--- a/tests/Infra/TestCase.php
+++ b/tests/Infra/TestCase.php
@@ -61,6 +61,8 @@ abstract class TestCase extends OrchestraTestCase
         // database
         $config->set('database.connections.testing.prefix', 'tests');
         $config->set('database.connections.pgsql.prefix', 'tests');
+        $config->set('database.connections.mysql.prefix', 'tests');
+        $config->set('database.connections.mariadb.prefix', 'tests');
         $config->set('database.connections.mariadb.port', 3307);
 
         // new table name's


### PR DESCRIPTION
This reverts commit 19bd0915cd73b288431a1fafa53b0d30091c0a01.