### PR TITLE
fix: use PascalCase RoundingMode cases for brick/math ^0.14 compatibility

### DIFF
--- a/src/Internal/Service/MathService.php
+++ b/src/Internal/Service/MathService.php
@@ -18,34 +18,34 @@ final readonly class MathService implements MathServiceInterface
     {
         return (string) BigDecimal::of($first)
             ->plus(BigDecimal::of($second))
-            ->toScale($scale ?? $this->scale, RoundingMode::DOWN);
+            ->toScale($scale ?? $this->scale, RoundingMode::Down);
     }
 
     public function sub(float|int|string $first, float|int|string $second, ?int $scale = null): string
     {
         return (string) BigDecimal::of($first)
             ->minus(BigDecimal::of($second))
-            ->toScale($scale ?? $this->scale, RoundingMode::DOWN);
+            ->toScale($scale ?? $this->scale, RoundingMode::Down);
     }
 
     public function div(float|int|string $first, float|int|string $second, ?int $scale = null): string
     {
         return (string) BigDecimal::of($first)
-            ->dividedBy(BigDecimal::of($second), $scale ?? $this->scale, RoundingMode::DOWN);
+            ->dividedBy(BigDecimal::of($second), $scale ?? $this->scale, RoundingMode::Down);
     }
 
     public function mul(float|int|string $first, float|int|string $second, ?int $scale = null): string
     {
         return (string) BigDecimal::of($first)
             ->multipliedBy(BigDecimal::of($second))
-            ->toScale($scale ?? $this->scale, RoundingMode::DOWN);
+            ->toScale($scale ?? $this->scale, RoundingMode::Down);
     }
 
     public function pow(float|int|string $first, float|int|string $second, ?int $scale = null): string
     {
         return (string) BigDecimal::of($first)
             ->power((int) $second)
-            ->toScale($scale ?? $this->scale, RoundingMode::DOWN);
+            ->toScale($scale ?? $this->scale, RoundingMode::Down);
     }
 
     public function powTen(float|int|string $number): string
@@ -56,19 +56,19 @@ final readonly class MathService implements MathServiceInterface
     public function ceil(float|int|string $number): string
     {
         return (string) BigDecimal::of($number)
-            ->dividedBy(BigDecimal::one(), 0, RoundingMode::CEILING);
+            ->dividedBy(BigDecimal::one(), 0, RoundingMode::Ceiling);
     }
 
     public function floor(float|int|string $number): string
     {
         return (string) BigDecimal::of($number)
-            ->dividedBy(BigDecimal::one(), 0, RoundingMode::FLOOR);
+            ->dividedBy(BigDecimal::one(), 0, RoundingMode::Floor);
     }
 
     public function round(float|int|string $number, int $precision = 0): string
     {
         return (string) BigDecimal::of($number)
-            ->dividedBy(BigDecimal::one(), $precision, RoundingMode::HALF_UP);
+            ->dividedBy(BigDecimal::one(), $precision, RoundingMode::HalfUp);
     }
 
     public function abs(float|int|string $number): string

--- a/src/Services/FormatterService.php
+++ b/src/Services/FormatterService.php
@@ -17,7 +17,7 @@ final readonly class FormatterService implements FormatterServiceInterface
         return (string) BigDecimal::ten()
             ->power($decimalPlaces)
             ->multipliedBy(BigDecimal::of($amount))
-            ->toScale(0, RoundingMode::DOWN);
+            ->toScale(0, RoundingMode::Down);
     }
 
     public function floatValue(string|int|float $amount, int $decimalPlaces): string


### PR DESCRIPTION
## Problem

`composer.json` declares `brick/math: ^0.14.2 || ^0.15 || ^0.16 || ^0.17`, but `src/Internal/Service/MathService.php` and `src/Services/FormatterService.php` still reference `RoundingMode` constants in `SCREAMING_SNAKE_CASE` (e.g. `RoundingMode::DOWN`, `RoundingMode::HALF_UP`).

In `brick/math 0.14`, `Brick\Math\RoundingMode` was converted from a class with `SCREAMING_SNAKE_CASE` class constants into a native PHP enum with `PascalCase` cases (`Down`, `Ceiling`, `Floor`, `HalfUp`, etc.). The old identifiers no longer exist on the enum, so any install resolving `brick/math` to `^0.14` (the lowest currently allowed range) immediately fatals when these services are used:

```
Error: Undefined constant Brick\Math\RoundingMode::DOWN
```

This affects fresh installs of `bavix/laravel-wallet ^11.4` / `11.5.0` with Composer picking the latest `brick/math`.

## Change

Replaces all `RoundingMode` references in the two affected files with their PascalCase enum-case equivalents:

| Before                   | After                   |
|--------------------------|-------------------------|
| `RoundingMode::DOWN`     | `RoundingMode::Down`    |
| `RoundingMode::CEILING`  | `RoundingMode::Ceiling` |
| `RoundingMode::FLOOR`    | `RoundingMode::Floor`   |
| `RoundingMode::HALF_UP`  | `RoundingMode::HalfUp`  |

Only `src/Internal/Service/MathService.php` and `src/Services/FormatterService.php` are touched; no other behavior changes.

## Compatibility

`brick/math` defines the enum cases (PascalCase) starting in `0.14.0`. The minimum version allowed by this package's `composer.json` is `^0.14.2`, so this change does not narrow the supported range. Older `brick/math` versions (`^0.13` and below) are already excluded by the existing constraint.

## Test plan

- [ ] CI suite passes on `brick/math 0.14.x`
- [ ] CI suite passes on `brick/math 0.17.x` (current latest)
- [ ] No remaining references to the old constants:
  ```
  grep -r "RoundingMode::\(DOWN\|UP\|CEILING\|FLOOR\|HALF_\)" src/
  ```