### PR TITLE
Avoid define observer within boot method of models

### DIFF
--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -12,6 +12,7 @@ use Bavix\Wallet\Models\Wallet as WalletModel;
 use Bavix\Wallet\Services\CastServiceInterface;
 use function config;
 use DateTimeInterface;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
@@ -51,6 +52,7 @@ use Override;
     'created_at',
     'updated_at',
 ])]
+#[ObservedBy(TransactionObserver::class)]
 class Transaction extends Model
 {
     use SoftDeletes;
@@ -131,11 +133,5 @@ class Transaction extends Model
             'meta' => 'json',
             'type' => TransactionType::class,
         ];
-    }
-
-    #[Override]
-    protected static function booted(): void
-    {
-        static::observe(TransactionObserver::class);
     }
 }

--- a/src/Models/Transfer.php
+++ b/src/Models/Transfer.php
@@ -8,6 +8,7 @@ use Bavix\Wallet\Enums\TransferStatus;
 use Bavix\Wallet\Internal\Observers\TransferObserver;
 use function config;
 use DateTimeInterface;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -49,6 +50,7 @@ use Override;
     'created_at',
     'updated_at',
 ])]
+#[ObservedBy(TransferObserver::class)]
 class Transfer extends Model
 {
     use SoftDeletes;
@@ -130,11 +132,5 @@ class Transfer extends Model
             'status' => TransferStatus::class,
             'status_last' => TransferStatus::class,
         ];
-    }
-
-    #[Override]
-    protected static function booted(): void
-    {
-        static::observe(TransferObserver::class);
     }
 }


### PR DESCRIPTION
Observe in the `boot` method of the model will create recursion when booting the model

As of Laravel v13, creating a new model while the model is booting is not allowed.
and will throw this exception:

> The [bootIfNotBooted] method may not be called on model [ANY MODEL] while it is being booted.
The actual code which throwing this exception is:
```php
    protected function bootIfNotBooted()
    {
        if (! isset(static::$booted[static::class])) {
            if (isset(static::$booting[static::class])) {
                throw new LogicException('The ['.__METHOD__.'] method may not be called on model ['.static::class.'] while it is being booted.');
            }
.
.
.
```
see: https://github.com/laravel/framework/blob/f3a7e5018730ddcb117d88fb7e407ec49ec69a96/src/Illuminate/Database/Eloquent/Model.php#L335


We have **2** solutions for this:

1.  Using **[ObservedBy](https://github.com/laravel/framework/blob/13.x/src/Illuminate/Database/Eloquent/Attributes/ObservedBy.php)** attribute.
I chose this one because we defined a minimum version of Laravel at least v13, and this attribute was introduced in v10
See: https://github.com/laravel/framework/pull/49843
Also, the minimum version of PHP (v 8.3) is enough to support attributes which is introduced in PHP v8.0

2. Define using **whenBooted** which can be defined using this code:
```php
    #[Override]
    protected static function booted(): void
    {
        static::whenBooted(
            static fn() => static:observe(TransferObserver::class)
        );
    }

```

See: https://github.com/laravel/framework/pull/55685
See: https://github.com/laravel/framework/pull/55286/files#diff-6b7a1e8941a2ef848d57cd87f1b6658028d001a11b6d4b6d6b110a9bc18bf6b5