### PR TITLE
Ensure data types of config values

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -496,7 +496,14 @@ return [
         /**
          * The configuration options for creating wallets.
          *
-         * @var array<string, mixed>
+         * @var array{
+         *     name?: string,
+         *     slug?: string,
+         *     description?: string,
+         *     meta?: array<mixed>|null,
+         *     balance?: int,
+         *     decimal_places?: int,
+         * }
          */
         'creating' => [],
 

--- a/src/Internal/Repository/WalletRepository.php
+++ b/src/Internal/Repository/WalletRepository.php
@@ -162,7 +162,7 @@ final readonly class WalletRepository implements WalletRepositoryInterface
     public function findDefaultAll(string $holderType, array $holderIds): array
     {
         return $this->wallet->newQuery()
-            ->where('slug', config('wallet.wallet.default.slug', 'default'))
+            ->where('slug', config()->string('wallet.wallet.default.slug', 'default'))
             ->where('holder_type', $holderType)
             ->whereIn('holder_id', $holderIds)
             ->get()

--- a/src/Internal/Repository/WalletRepositoryInterface.php
+++ b/src/Internal/Repository/WalletRepositoryInterface.php
@@ -19,7 +19,7 @@ interface WalletRepositoryInterface
      *     slug?: string,
      *     uuid: string,
      *     description?: string,
-     *     meta: array<mixed>|null,
+     *     meta?: array<mixed>|null,
      *     balance?: int,
      *     decimal_places?: int,
      * } $attributes

--- a/src/Internal/Service/LockService.php
+++ b/src/Internal/Service/LockService.php
@@ -25,8 +25,8 @@ final class LockService implements LockServiceInterface
         CacheFactory $cacheFactory,
         private readonly int $seconds
     ) {
-        /** @var string|null $lockDriver */
-        $lockDriver = config('wallet.lock.driver', 'array');
+        $lockDriver = config()
+            ->string('wallet.lock.driver', 'array');
         $this->cache = $cacheFactory->store($lockDriver);
         $this->lockedKeys = $cacheFactory->store('array');
     }

--- a/src/Models/Purchase.php
+++ b/src/Models/Purchase.php
@@ -37,9 +37,8 @@ final class Purchase extends Model
     public function getTable(): string
     {
         if ((string) $this->table === '') {
-            /** @var string $table */
-            $table = config('wallet.purchase.table', 'wallet_purchases');
-            $this->table = $table;
+            $this->table = config()
+                ->string('wallet.purchase.table', 'wallet_purchases');
         }
 
         return parent::getTable();
@@ -51,7 +50,8 @@ final class Purchase extends Model
     public function transfer(): BelongsTo
     {
         /** @var class-string<Transfer> $model */
-        $model = config('wallet.transfer.model', Transfer::class);
+        $model = config()
+            ->string('wallet.transfer.model', Transfer::class);
 
         return $this->belongsTo($model, 'transfer_id');
     }
@@ -62,7 +62,8 @@ final class Purchase extends Model
     public function from(): BelongsTo
     {
         /** @var class-string<Wallet> $model */
-        $model = config('wallet.wallet.model', Wallet::class);
+        $model = config()
+            ->string('wallet.wallet.model', Wallet::class);
 
         return $this->belongsTo($model, 'from_id');
     }
@@ -73,7 +74,8 @@ final class Purchase extends Model
     public function to(): BelongsTo
     {
         /** @var class-string<Wallet> $model */
-        $model = config('wallet.wallet.model', Wallet::class);
+        $model = config()
+            ->string('wallet.wallet.model', Wallet::class);
 
         return $this->belongsTo($model, 'to_id');
     }

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -59,9 +59,8 @@ class Transaction extends Model
     public function getTable(): string
     {
         if ((string) $this->table === '') {
-            /** @var string $table */
-            $table = config('wallet.transaction.table', 'transactions');
-            $this->table = $table;
+            $this->table = config()
+                ->string('wallet.transaction.table', 'transactions');
         }
 
         return parent::getTable();
@@ -81,7 +80,8 @@ class Transaction extends Model
     public function wallet(): BelongsTo
     {
         /** @var class-string<WalletModel> $model */
-        $model = config('wallet.wallet.model', WalletModel::class);
+        $model = config()
+            ->string('wallet.wallet.model', WalletModel::class);
         /** @var BelongsTo<WalletModel, self> $belongsTo */
         $belongsTo = $this->belongsTo($model);
 

--- a/src/Models/Transfer.php
+++ b/src/Models/Transfer.php
@@ -57,9 +57,8 @@ class Transfer extends Model
     public function getTable(): string
     {
         if ((string) $this->table === '') {
-            /** @var string $table */
-            $table = config('wallet.transfer.table', 'transfers');
-            $this->table = $table;
+            $this->table = config()
+                ->string('wallet.transfer.table', 'transfers');
         }
 
         return parent::getTable();
@@ -71,7 +70,8 @@ class Transfer extends Model
     public function from(): BelongsTo
     {
         /** @var class-string<Wallet> $model */
-        $model = config('wallet.wallet.model', Wallet::class);
+        $model = config()
+            ->string('wallet.wallet.model', Wallet::class);
         /** @var BelongsTo<Wallet, self> $belongsTo */
         $belongsTo = $this->belongsTo($model, 'from_id');
 
@@ -84,7 +84,8 @@ class Transfer extends Model
     public function to(): BelongsTo
     {
         /** @var class-string<Wallet> $model */
-        $model = config('wallet.wallet.model', Wallet::class);
+        $model = config()
+            ->string('wallet.wallet.model', Wallet::class);
         /** @var BelongsTo<Wallet, self> $belongsTo */
         $belongsTo = $this->belongsTo($model, 'to_id');
 
@@ -97,7 +98,8 @@ class Transfer extends Model
     public function deposit(): BelongsTo
     {
         /** @var class-string<Transaction> $model */
-        $model = config('wallet.transaction.model', Transaction::class);
+        $model = config()
+            ->string('wallet.transaction.model', Transaction::class);
         /** @var BelongsTo<Transaction, self> $belongsTo */
         $belongsTo = $this->belongsTo($model, 'deposit_id');
 
@@ -110,7 +112,8 @@ class Transfer extends Model
     public function withdraw(): BelongsTo
     {
         /** @var class-string<Transaction> $model */
-        $model = config('wallet.transaction.model', Transaction::class);
+        $model = config()
+            ->string('wallet.transaction.model', Transaction::class);
         /** @var BelongsTo<Transaction, self> $belongsTo */
         $belongsTo = $this->belongsTo($model, 'withdraw_id');
 

--- a/src/Models/Wallet.php
+++ b/src/Models/Wallet.php
@@ -89,9 +89,8 @@ class Wallet extends Model implements Customer, WalletFloat, Confirmable, Exchan
     public function getTable(): string
     {
         if ((string) $this->table === '') {
-            /** @var string $table */
-            $table = config('wallet.wallet.table', 'wallets');
-            $this->table = $table;
+            $this->table = config()
+                ->string('wallet.wallet.table', 'wallets');
         }
 
         return parent::getTable();

--- a/src/Services/WalletService.php
+++ b/src/Services/WalletService.php
@@ -27,15 +27,31 @@ final readonly class WalletService implements WalletServiceInterface
 
     public function create(Model $model, array $data): Wallet
     {
+        /**
+         * @var array{
+         *     name?: string,
+         *     slug?: string,
+         *     description?: string,
+         *     meta?: array<mixed>|null,
+         *     balance?: int,
+         *     decimal_places?: int,
+         * }
+         */
+        $default = config()
+            ->array('wallet.wallet.creating', []);
+
+        /** @var string|int $holderId */
+        $holderId = $model->getKey();
+
         $wallet = $this->walletRepository->create(array_merge(
-            config('wallet.wallet.creating', []),
+            $default,
             [
                 'uuid' => $this->identifierFactoryService->generate(),
             ],
             $data,
             [
                 'holder_type' => $model->getMorphClass(),
-                'holder_id' => $model->getKey(),
+                'holder_id' => $holderId,
             ]
         ));
 

--- a/src/Traits/HasWallet.php
+++ b/src/Traits/HasWallet.php
@@ -156,7 +156,9 @@ trait HasWallet
         // The transaction model class is retrieved from the configuration using `config('wallet.transaction.model', Transaction::class)`.
         // The relationship is defined using the `wallet_id` foreign key.
         /** @var class-string<Transaction> $model */
-        $model = config('wallet.transaction.model', Transaction::class);
+        $model = config()
+            ->string('wallet.transaction.model', Transaction::class);
+
         /** @var HasMany<Transaction, WalletModel> $transactions */
         $transactions = $wallet->hasMany($model, 'wallet_id');
 
@@ -187,7 +189,9 @@ trait HasWallet
         // The relationship is defined using the `payable` foreign key.
         // The `payable` foreign key is used to associate the transactions with the wallet.
         /** @var class-string<Transaction> $model */
-        $model = config('wallet.transaction.model', Transaction::class);
+        $model = config()
+            ->string('wallet.transaction.model', Transaction::class);
+
         /** @var MorphMany<Transaction, Model> $morphMany */
         $morphMany = $wallet->morphMany(
             $model,
@@ -465,7 +469,9 @@ trait HasWallet
         // The transfer model class is retrieved from the configuration using `config('wallet.transfer.model', Transfer::class)`.
         // The relationship is defined using the `from_id` foreign key.
         /** @var class-string<Transfer> $model */
-        $model = config('wallet.transfer.model', Transfer::class);
+        $model = config()
+            ->string('wallet.transfer.model', Transfer::class);
+
         /** @var HasMany<Transfer, WalletModel> $hasMany */
         $hasMany = $wallet
             ->hasMany(
@@ -505,7 +511,9 @@ trait HasWallet
         // The transfer model class is retrieved from the configuration using `config('wallet.transfer.model', Transfer::class)`.
         // The relationship is defined using the `to_id` foreign key.
         /** @var class-string<Transfer> $model */
-        $model = config('wallet.transfer.model', Transfer::class);
+        $model = config()
+            ->string('wallet.transfer.model', Transfer::class);
+
         /** @var HasMany<Transfer, WalletModel> $hasMany */
         $hasMany = $wallet
             ->hasMany(

--- a/src/Traits/HasWallets.php
+++ b/src/Traits/HasWallets.php
@@ -107,7 +107,9 @@ trait HasWallets
         // Define a MorphMany relationship between the current model (the "holder")
         // and the wallet model.
         /** @var class-string<WalletModel> $model */
-        $model = config('wallet.wallet.model', WalletModel::class);
+        $model = config()
+            ->string('wallet.wallet.model', WalletModel::class);
+
         /** @var MorphMany<WalletModel, Model> $morphMany */
         $morphMany = $this
             ->morphMany(

--- a/src/Traits/MorphOneWallet.php
+++ b/src/Traits/MorphOneWallet.php
@@ -34,7 +34,8 @@ trait MorphOneWallet
          *
          * @var class-string<WalletModel>
          */
-        $related = config('wallet.wallet.model', WalletModel::class);
+        $related = config()
+            ->string('wallet.wallet.model', WalletModel::class);
 
         // Eager load the wallet for the related model.
         /** @var MorphOne<WalletModel, Model> $morphOne */
@@ -44,7 +45,8 @@ trait MorphOneWallet
             ->withTrashed() // Include soft deleted wallets.
             ->where(
                 'slug',
-                (string) config('wallet.wallet.default.slug', 'default')
+                config()
+                    ->string('wallet.wallet.default.slug', 'default')
             ) // Filter by the default wallet slug.
             ->withDefault(static function (WalletModel $wallet, object $holder) use (
                 $castService
@@ -57,16 +59,20 @@ trait MorphOneWallet
                 /** @var string $slug */
                 $slug = method_exists($model, 'getDynamicDefaultSlug')
                     ? $model->getDynamicDefaultSlug()
-                    : config('wallet.wallet.default.slug', 'default');
+                    : config()
+                        ->string('wallet.wallet.default.slug', 'default');
 
                 // Fill the default wallet attributes.
                 /** @var array<string, mixed> $creating */
-                $creating = config('wallet.wallet.creating', []);
+                $creating = config()
+                    ->array('wallet.wallet.creating', []);
                 /** @var array<string, mixed> $defaultMeta */
-                $defaultMeta = config('wallet.wallet.default.meta', []);
+                $defaultMeta = config()
+                    ->array('wallet.wallet.default.meta', []);
                 /** @var array<string, mixed> $attributes */
                 $attributes = array_merge($creating, [
-                    'name' => (string) config('wallet.wallet.default.name', 'Default Wallet'), // Default wallet name.
+                    'name' => config()
+                        ->string('wallet.wallet.default.name', 'Default Wallet'), // Default wallet name.
                     'slug' => $slug, // Default wallet slug.
                     'meta' => $defaultMeta, // Default wallet metadata.
                     'balance' => 0, // Default wallet balance.

--- a/src/WalletServiceProvider.php
+++ b/src/WalletServiceProvider.php
@@ -188,7 +188,8 @@ final class WalletServiceProvider extends ServiceProvider implements DeferrableP
          *     wallet?: array{model?: class-string|null},
          * } $configure
          */
-        $configure = config('wallet', []);
+        $configure = config()
+            ->array('wallet', []);
 
         $this->internal($configure['internal'] ?? []);
         $this->services($configure['services'] ?? [], $configure['cache'] ?? []);

--- a/tests/Units/Domain/CartReceivingTest.php
+++ b/tests/Units/Domain/CartReceivingTest.php
@@ -250,8 +250,9 @@ final class CartReceivingTest extends TestCase
         $firstTransfer = reset($transfers);
         self::assertInstanceOf(Transfer::class, $firstTransfer);
 
-        /** @var string $purchaseTable */
-        $purchaseTable = config('wallet.purchase.table', 'purchase');
+        $purchaseTable = config()
+            ->string('wallet.purchase.table', 'purchase');
+
         DB::table($purchaseTable)
             ->where('transfer_id', $firstTransfer->getKey())
             ->delete();
@@ -282,8 +283,9 @@ final class CartReceivingTest extends TestCase
         $firstTransfer = reset($transfers);
         self::assertInstanceOf(Transfer::class, $firstTransfer);
 
-        /** @var string $purchaseTable */
-        $purchaseTable = config('wallet.purchase.table', 'purchase');
+        $purchaseTable = config()
+            ->string('wallet.purchase.table', 'purchase');
+
         DB::table($purchaseTable)
             ->where('transfer_id', $firstTransfer->getKey())
             ->delete();

--- a/tests/Units/Domain/GiftTest.php
+++ b/tests/Units/Domain/GiftTest.php
@@ -122,8 +122,9 @@ final class GiftTest extends TestCase
         $first->deposit($product->getAmountProduct($first));
         $transfer = $first->wallet->gift($second, $product);
 
-        /** @var string $purchaseTable */
-        $purchaseTable = config('wallet.purchase.table', 'purchase');
+        $purchaseTable = config()
+            ->string('wallet.purchase.table', 'purchase');
+
         DB::table($purchaseTable)
             ->where('transfer_id', $transfer->getKey())
             ->delete();

--- a/tests/Units/Domain/ModelTableTest.php
+++ b/tests/Units/Domain/ModelTableTest.php
@@ -64,8 +64,8 @@ final class ModelTableTest extends TestCase
         $from->deposit(100);
         $transfer = $from->transfer($to, 30);
 
-        /** @var string $purchaseTable */
-        $purchaseTable = config('wallet.purchase.table', 'purchase');
+        $purchaseTable = config()
+            ->string('wallet.purchase.table', 'purchase');
         self::assertFalse(DB::table($purchaseTable)->where('transfer_id', $transfer->getKey())->exists());
     }
 


### PR DESCRIPTION
As of Laravel v11, we have support for typed getters when retrieving config values
See: https://github.com/laravel/framework/pull/50140

It defines scalar data types as getters on the Config repository, like: string, integer, float, boolean, and array.

Instead of defining the type of config values using PHPdoc to make static analysis tools understand this, we can use these getters and ensure the return value is the same as we expected. No PHPDoc anymore.