### PR TITLE
Allow zero decimal places in createWallet type

### DIFF
--- a/src/Traits/HasWallets.php
+++ b/src/Traits/HasWallets.php
@@ -145,7 +145,7 @@ trait HasWallets
      *     slug?: string,
      *     description?: string,
      *     meta?: array<mixed>|null,
-     *     decimal_places?: positive-int,
+     *     decimal_places?: int<0, max>,
      * } $data The data for the new wallet.
      * @return WalletModel The new wallet object.
      */


### PR DESCRIPTION
`createWallet()` documents `decimal_places?: positive-int`, but zero decimal places is a valid and supported configuration: the column is an unsigned integer, `WalletRepositoryInterface::create()` types the same key as `int`, and integer-only wallets (bonus points, whole-currency balances) rely on it.

With the current docblock PHPStan reports every such call:

```
Parameter #1 $data of method createWallet() expects array{..., decimal_places?: int<1, max>}, array{..., decimal_places: 0} given.
```

This aligns the docblock with the repository contract and the database schema.