### PR TITLE
Backport zero decimal places in createWallet type to 11.x

### DIFF
--- a/src/Traits/HasWallets.php
+++ b/src/Traits/HasWallets.php
@@ -143,7 +143,7 @@ trait HasWallets
      *     slug?: string,
      *     description?: string,
      *     meta?: array<mixed>|null,
-     *     decimal_places?: positive-int,
+     *     decimal_places?: int<0, max>,
      * } $data The data for the new wallet.
      * @return WalletModel The new wallet object.
      */


### PR DESCRIPTION
Backport of #1108 (merged into `master`) to the maintained `11.x` branch.

`createWallet()` documents `decimal_places?: positive-int`, while the column is an unsigned integer and `WalletRepositoryInterface::create()` types the same key as `int`. Integer-only wallets (bonus points, whole-currency balances) pass `0` and PHPStan reports every such call:

```
Parameter #1 $data of method createWallet() expects array{..., decimal_places?: int<1, max>}, array{..., decimal_places: 0} given.
```

Applications on Laravel 11/12 cannot take the fix from 12.x, since that branch requires `illuminate/contracts ^13.0`. Same one-line docblock change as the master fix.