### PR TITLE
fix(ci): restore rector on 11.x

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -4,30 +4,19 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\Plus\RemoveDeadZeroAndOneOperationRector;
-use Rector\Set\ValueObject\SetList;
 use RectorLaravel\Rector\ClassMethod\MigrateToSimplifiedAttributeRector;
 use RectorLaravel\Set\LaravelLevelSetList;
 
-return static function (RectorConfig $config): void {
-    $config->parallel();
-    $config->paths([
-        __DIR__ . '/src',
-        __DIR__ . '/tests',
-    ]);
-
-    // remove it in next version
-    $config->skip([
-        MigrateToSimplifiedAttributeRector::class,
-        RemoveDeadZeroAndOneOperationRector::class,
-    ]);
-
-    // Define what rule sets will be applied
-    $config->import(LaravelLevelSetList::UP_TO_LARAVEL_110);
-    $config->import(SetList::STRICT_BOOLEANS);
-    $config->import(SetList::PRIVATIZATION);
-    $config->import(SetList::EARLY_RETURN);
-    $config->import(SetList::INSTANCEOF);
-    $config->import(SetList::CODE_QUALITY);
-    $config->import(SetList::DEAD_CODE);
-    $config->import(SetList::PHP_83);
-};
+return RectorConfig::configure()
+    ->withParallel()
+    ->withPaths([__DIR__ . '/src', __DIR__ . '/tests'])
+    ->withSkip([MigrateToSimplifiedAttributeRector::class, RemoveDeadZeroAndOneOperationRector::class])
+    ->withSets([LaravelLevelSetList::UP_TO_LARAVEL_110])
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+        privatization: true,
+        instanceOf: true,
+        earlyReturn: true,
+    )
+    ->withPhpSets(php83: true);

--- a/src/Internal/Observers/TransferObserver.php
+++ b/src/Internal/Observers/TransferObserver.php
@@ -42,13 +42,12 @@ final readonly class TransferObserver
         // If the transfer does not belong to the wallet, a WalletOwnerInvalid exception will be thrown.
         // If the transfer was not found, a RecordNotFoundException will be thrown.
         // Block both the wallet of the user who is sending the money and the wallet of the user who is receiving the money.
-        return $this->atomicService->blocks([$model->from, $model->to], function () use ($model) {
+        return $this->atomicService->blocks([$model->from, $model->to],
             // Reset confirmation of the transfer for the sender's wallet.
             // Returns true if the confirmation was reset, false otherwise.
-            return $model->from->safeResetConfirm($model->withdraw)
-                // Reset confirmation of the transfer for the receiver's wallet.
-                // Returns true if the confirmation was reset, false otherwise.
-                && $model->to->safeResetConfirm($model->deposit);
-        });
+            fn () => $model->from->safeResetConfirm($model->withdraw)
+            // Reset confirmation of the transfer for the receiver's wallet.
+            // Returns true if the confirmation was reset, false otherwise.
+            && $model->to->safeResetConfirm($model->deposit));
     }
 }

--- a/src/Services/EagerLoaderServiceInterface.php
+++ b/src/Services/EagerLoaderServiceInterface.php
@@ -20,8 +20,6 @@ use Bavix\Wallet\Internal\Dto\BasketDtoInterface;
 interface EagerLoaderServiceInterface
 {
     /**
-     * Load wallets by basket.
-     *
      * This method is responsible for loading wallets by basket.
      * The Customer object represents the customer who created the basket.
      * The BasketDtoInterface object represents the basket.

--- a/src/Traits/CanConfirm.php
+++ b/src/Traits/CanConfirm.php
@@ -97,10 +97,10 @@ trait CanConfirm
         try {
             // Attempt to confirm the transaction
             return $this->confirm($transaction);
-        } catch (ConfirmedInvalid $e) {
+        } catch (ConfirmedInvalid) {
             // If the transaction is already confirmed, return true
             return true;
-        } catch (ExceptionInterface $e) {
+        } catch (ExceptionInterface) {
             // If an exception occurred, return false
             return false;
         }
@@ -164,10 +164,10 @@ trait CanConfirm
         try {
             // Attempt to reset the confirmation of the transaction
             return $this->resetConfirm($transaction);
-        } catch (UnconfirmedInvalid $e) {
+        } catch (UnconfirmedInvalid) {
             // If the transaction is not confirmed, simply return true
             return true;
-        } catch (ExceptionInterface $e) {
+        } catch (ExceptionInterface) {
             // If an exception occurs, return false
             return false;
         }

--- a/src/Traits/CanExchange.php
+++ b/src/Traits/CanExchange.php
@@ -85,7 +85,7 @@ trait CanExchange
             // Execute the exchange operation and return the created transfer.
             // If an error occurs during the process, an exception is thrown.
             return $this->exchange($to, $amount, $meta);
-        } catch (ExceptionInterface $e) {
+        } catch (ExceptionInterface) {
             // If an exception occurs during the exchange process, return null.
             return null;
         }

--- a/src/Traits/CartPay.php
+++ b/src/Traits/CartPay.php
@@ -150,7 +150,7 @@ trait CartPay
         try {
             // If the payment is successful, return the array of Transfer instances.
             return $this->payCart($cart, $force);
-        } catch (ExceptionInterface $exception) {
+        } catch (ExceptionInterface) {
             // If the payment fails, return an empty array.
             return [];
         }
@@ -299,7 +299,7 @@ trait CartPay
         try {
             // Try to refund all items in the provided cart.
             return $this->refundCart($cart, $force, $gifts);
-        } catch (ExceptionInterface $e) {
+        } catch (ExceptionInterface) {
             // Return false if an exception occurs during the refund process.
             // This is a safe refund method, so we do not rethrow the exception.
             return false;
@@ -457,7 +457,7 @@ trait CartPay
         try {
             // Attempt to refund all gifts in the provided cart.
             return $this->refundGiftCart($cart, $force);
-        } catch (ExceptionInterface $e) {
+        } catch (ExceptionInterface) {
             // Return false if an exception occurs during the refund process.
             // This is a safe refund method, so we do not rethrow the exception.
             return false;

--- a/src/Traits/HasGift.php
+++ b/src/Traits/HasGift.php
@@ -50,7 +50,7 @@ trait HasGift
         try {
             // Attempt to give the goods to the specified wallet
             return $this->gift($to, $product, $force);
-        } catch (ExceptionInterface $exception) {
+        } catch (ExceptionInterface) {
             // If an exception occurs, return null
             return null;
         }

--- a/src/Traits/HasWallet.php
+++ b/src/Traits/HasWallet.php
@@ -226,7 +226,7 @@ trait HasWallet
             // The `transfer` method is responsible for performing the actual transfer of funds.
             // If an error occurs during the process, an exception is thrown.
             return $this->transfer($wallet, $amount, $meta);
-        } catch (ExceptionInterface $e) {
+        } catch (ExceptionInterface) {
             return null;
         }
     }
@@ -364,21 +364,20 @@ trait HasWallet
         return app(AtomicServiceInterface::class)->block(
         // The wallet instance
             $this,
-            function () use ($amountValue, $meta, $confirmed): Transaction {
+
                 // Create a new withdrawal transaction.
-                return app(TransactionServiceInterface::class)->makeOne(
-                // The wallet instance
-                    $this,
-                    // The transaction type
-                    Transaction::TYPE_WITHDRAW,
-                    // The amount to withdraw
-                    $amountValue,
-                    // Additional information for the transaction
-                    $meta,
-                    // Whether the transaction is confirmed
-                    $confirmed
-                );
-            }
+                fn (): Transaction => app(TransactionServiceInterface::class)->makeOne(
+            // The wallet instance
+                $this,
+                // The transaction type
+                Transaction::TYPE_WITHDRAW,
+                // The amount to withdraw
+                $amountValue,
+                // Additional information for the transaction
+                $meta,
+                // Whether the transaction is confirmed
+                $confirmed
+            )
         );
     }
 

--- a/src/Traits/HasWallets.php
+++ b/src/Traits/HasWallets.php
@@ -44,7 +44,7 @@ trait HasWallets
         // Try to get the wallet with the given slug.
         try {
             return $this->getWalletOrFail($slug);
-        } catch (ModelNotFoundException $exception) {
+        } catch (ModelNotFoundException) {
             // If the wallet is not found, return null.
             return null;
         }

--- a/src/Traits/MorphOneWallet.php
+++ b/src/Traits/MorphOneWallet.php
@@ -83,8 +83,6 @@ trait MorphOneWallet
     }
 
     /**
-     * Get the wallet attribute.
-     *
      * @return WalletModel|null The wallet model associated with the related model.
      */
     public function getWalletAttribute(): ?WalletModel

--- a/src/WalletServiceProvider.php
+++ b/src/WalletServiceProvider.php
@@ -298,15 +298,13 @@ final class WalletServiceProvider extends ServiceProvider implements DeferrableP
         // bookkeepper service
         $this->app->when(StorageServiceLockDecorator::class)
             ->needs(StorageServiceInterface::class)
-            ->give(function () use ($cache) {
-                return $this->app->make(
-                    'wallet.internal.storage',
-                    [
-                        'cacheRepository' => $this->app->get(CacheFactory::class)
-                            ->store($cache['driver'] ?? 'array'),
-                    ],
-                );
-            });
+            ->give(fn () => $this->app->make(
+                'wallet.internal.storage',
+                [
+                    'cacheRepository' => $this->app->get(CacheFactory::class)
+                        ->store($cache['driver'] ?? 'array'),
+                ],
+            ));
 
         $this->app->when($configure['bookkeeper'] ?? BookkeeperService::class)
             ->needs(StorageServiceInterface::class)
@@ -317,15 +315,13 @@ final class WalletServiceProvider extends ServiceProvider implements DeferrableP
         // regulator service
         $this->app->when($configure['regulator'] ?? RegulatorService::class)
             ->needs(StorageServiceInterface::class)
-            ->give(function () {
-                return $this->app->make(
-                    'wallet.internal.storage',
-                    [
-                        'cacheRepository' => clone $this->app->make(CacheFactory::class)
-                            ->store('array'),
-                    ],
-                );
-            });
+            ->give(fn () => $this->app->make(
+                'wallet.internal.storage',
+                [
+                    'cacheRepository' => clone $this->app->make(CacheFactory::class)
+                        ->store('array'),
+                ],
+            ));
 
         $this->app->singleton(RegulatorServiceInterface::class, $configure['regulator'] ?? RegulatorService::class);
     }

--- a/tests/Units/Domain/ConfirmTest.php
+++ b/tests/Units/Domain/ConfirmTest.php
@@ -243,7 +243,7 @@ final class ConfirmTest extends TestCase
         /**
          * @var Buyer $buyer1
          * @var Buyer $buyer2
-         **/
+         */
         [$buyer1, $buyer2] = BuyerFactory::times(2)->create();
         $wallet1 = $buyer1->wallet;
         $wallet2 = $buyer2->wallet;

--- a/tests/Units/Service/AtomicServiceTest.php
+++ b/tests/Units/Service/AtomicServiceTest.php
@@ -105,7 +105,7 @@ final class AtomicServiceTest extends TestCase
 
             // This should not be reached
             $this->assertTrue(false); // check
-        } catch (\Throwable $e) {
+        } catch (\Throwable) {
             // Intentionally left empty
         }
 

--- a/tests/Units/Service/WalletTest.php
+++ b/tests/Units/Service/WalletTest.php
@@ -69,7 +69,7 @@ final class WalletTest extends TestCase
         $uuidFactoryService = app(IdentifierFactoryServiceInterface::class);
 
         /** @var string[] $uuids */
-        $uuids = array_map(static fn () => $uuidFactoryService->generate(), range(1, 10));
+        $uuids = array_map($uuidFactoryService->generate(...), range(1, 10));
 
         foreach ($uuids as $uuid) {
             $user->createWallet([


### PR DESCRIPTION
Fixes #1111.

`SetList::STRICT_BOOLEANS` no longer exists in Rector 2, so `rector.php` on `11.x` aborts with `Undefined constant` and the `fixer` workflow fails on every pull request against this branch regardless of its content.

- `rector.php` ported to the builder API used on `master`, with the same sets minus the removed one: Laravel level set `UP_TO_LARAVEL_110`, prepared sets `deadCode`, `codeQuality`, `privatization`, `instanceOf`, `earlyReturn`, and `withPhpSets(php83: true)`. Skips are unchanged.
- Second commit-worth of changes are what `rector-fix` and `ecs-fix` produce on the first run after the config works again — drift accumulated while it did not: `ClosureToArrowFunctionRector`, `ArrowFunctionDelegatingCallToFirstClassCallableRector`, `RemoveUnusedVariableInCatchRector` in 10 files, plus 6 ECS fixes. They are included here so the workflow lands green instead of pushing them itself.

Verified locally on PHP 8.3: `rector` and `ecs` report no remaining changes, full suite is green (249 tests, 2242 assertions).
