### PR TITLE
Remove redundant indexes

### DIFF
--- a/database/2026_08_16_000004_remove_redundant_indexes.php
+++ b/database/2026_08_16_000004_remove_redundant_indexes.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Bavix\Wallet\Models\Transaction;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        $tableName = $this->table();
+        $indexes = $this->indexes();
+
+        Schema::table($tableName, static function (Blueprint $table) use ($tableName, $indexes): void {
+            foreach (array_keys($indexes) as $index) {
+                if (Schema::hasIndex($tableName, $index)) {
+                    $table->dropIndex($index);
+                }
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        $tableName = $this->table();
+        $indexes = $this->indexes();
+
+        Schema::table($tableName, static function (Blueprint $table) use ($tableName, $indexes): void {
+            foreach ($indexes as $index => $columns) {
+                if (! Schema::hasIndex($tableName, $index)) {
+                    $table->index($columns, $index);
+                }
+            }
+        });
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    private function indexes(): array
+    {
+        return [
+            'payable_type_payable_id_ind' => ['payable_type', 'payable_id'],
+            'payable_type_ind' => ['payable_type', 'payable_id', 'type'],
+        ];
+    }
+
+    private function table(): string
+    {
+        return (new Transaction())->getTable();
+    }
+};


### PR DESCRIPTION
This pull request removes two redundant indexes:

`payable_type_payable_id_ind`: An exact duplicate of the index created by `morphs('payable')`,

`payable_type_ind`: A prefix of `payable_type_confirmed_ind` - The longer index can support the same leading-column lookup.

I made it defensive, so if the user had already removed those indexes, it won't fail.

For release notes:
If you previously published the wallet migrations into your application, publish them again with `php artisan vendor:publish --tag=laravel-wallet-migrations`