### PR TITLE
Feature/remove redundant indexes (narrower indexes)

### DIFF
--- a/database/2026_08_16_000004_remove_redundant_indexes.php
+++ b/database/2026_08_16_000004_remove_redundant_indexes.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Bavix\Wallet\Models\Transaction;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        $tableName = $this->table();
+        $indexes = $this->indexes();
+
+        Schema::table($tableName, static function (Blueprint $table) use ($tableName, $indexes): void {
+            foreach (array_keys($indexes) as $index) {
+                if (Schema::hasIndex($tableName, $index)) {
+                    $table->dropIndex($index);
+                }
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        $tableName = $this->table();
+        $indexes = $this->indexes();
+
+        Schema::table($tableName, static function (Blueprint $table) use ($tableName, $indexes): void {
+            foreach ($indexes as $index => $columns) {
+                if (! Schema::hasIndex($tableName, $index)) {
+                    $table->index($columns, $index);
+                }
+            }
+        });
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    private function indexes(): array
+    {
+        return [
+            'payable_type_payable_id_ind' => ['payable_type', 'payable_id'],
+            'payable_type_ind' => ['payable_type', 'payable_id', 'type'],
+        ];
+    }
+
+    private function table(): string
+    {
+        return (new Transaction())->getTable();
+    }
+};

--- a/database/2026_08_16_000005_remove_redundant_narrow_indexes.php
+++ b/database/2026_08_16_000005_remove_redundant_narrow_indexes.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Bavix\Wallet\Models\Transaction;
+use Bavix\Wallet\Models\Wallet;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        $transactionTable = $this->transactionTable();
+        $walletTable = $this->walletTable();
+
+        Schema::table($transactionTable, static function (Blueprint $table) use ($transactionTable): void {
+            $indexName = $transactionTable.'_payable_type_payable_id_index';
+
+            if (Schema::hasIndex($transactionTable, $indexName)) {
+                $table->dropIndex($indexName);
+            }
+        });
+
+        Schema::table($walletTable, static function (Blueprint $table) use ($walletTable): void {
+            $indexName = $walletTable.'_holder_type_holder_id_index';
+
+            if (Schema::hasIndex($walletTable, $indexName)) {
+                $table->dropIndex($indexName);
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        $transactionTable = $this->transactionTable();
+        $walletTable = $this->walletTable();
+
+        Schema::table($transactionTable, static function (Blueprint $table) use ($transactionTable): void {
+            $indexName = $transactionTable.'_payable_type_payable_id_index';
+
+            if (! Schema::hasIndex($transactionTable, $indexName)) {
+                $table->index(['payable_type', 'payable_id'], $indexName);
+            }
+        });
+
+        Schema::table($walletTable, static function (Blueprint $table) use ($walletTable): void {
+            $indexName = $walletTable.'_holder_type_holder_id_index';
+
+            if (! Schema::hasIndex($walletTable, $indexName)) {
+                $table->index(['holder_type', 'holder_id'], $indexName);
+            }
+        });
+    }
+
+    private function transactionTable(): string
+    {
+        return (new Transaction())->getTable();
+    }
+
+    private function walletTable(): string
+    {
+        return (new Wallet())->getTable();
+    }
+};


### PR DESCRIPTION
This pull request removes two more redundant indexes.

I made it a separate pull request as it's a judgement call if these are necessary. I strongly believe it is a good idea to remove them, as they're just narrower indexes of already existing indexes. Users will probably benefit more from freed DB cache memory than the smaller index surface.

`transactions_payable_type_payable_id_index`: narrower prefix of `payable_type_confirmed_ind`.

`wallets_holder_type_holder_id_index`: Narrower prefix of the unique `holder_type, holder_id, slug` index.

I made it defensive, so if the user had already removed those indexes, it won't fail.

For release notes:
If you previously published the wallet migrations into your application, publish them again with `php artisan vendor:publish --tag=laravel-wallet-migrations`